### PR TITLE
Add client and professional pages with basic layout

### DIFF
--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cadastro Cliente - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleSignup(event) {
+      event.preventDefault();
+      alert('Cadastro de cliente - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Cadastro de Cliente</h1>
+  <form onsubmit="handleSignup(event)">
+    <label for="nome">Nome</label>
+    <input type="text" id="nome" required>
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required>
+    <button type="submit" class="btn">Salvar</button>
+  </form>
+  <a href="index.html" class="btn">Voltar</a>
+</body>
+</html>

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cliente - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleLogin(event) {
+      event.preventDefault();
+      alert('Login de cliente - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Área da Cliente</h1>
+  <form onsubmit="handleLogin(event)">
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="password">Senha</label>
+    <input type="password" id="password" required>
+    <button type="submit" class="btn">Entrar</button>
+  </form>
+  <p>Ainda não tem conta?</p>
+  <a href="cadastro.html" class="btn">Cadastrar</a>
+  <br>
+  <a href="../" class="btn">Início</a>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,29 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NailNow 💅</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      background: #fff0f6;
-      color: #333;
-      margin: 0;
-      padding: 45px;
-    }
-    h1 { font-size: 2.5rem; margin-bottom: 20px; }
-    .btn {
-      display: inline-block;
-      margin: 15px;
-      padding: 15px 30px;
-      font-size: 1.2rem;
-      border-radius: 12px;
-      text-decoration: none;
-      background: #ff69b4;
-      color: white;
-      transition: 0.3s;
-    }
-    .btn:hover { background: #ff85c1; }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <h1>Bem-vinda ao NailNow 💅</h1>

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cadastro Profissional - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleSignup(event) {
+      event.preventDefault();
+      alert('Cadastro de profissional - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Cadastro de Profissional</h1>
+  <form onsubmit="handleSignup(event)">
+    <label for="nome">Nome</label>
+    <input type="text" id="nome" required>
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="cidade">Cidade</label>
+    <input type="text" id="cidade" required>
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required>
+    <button type="submit" class="btn">Salvar</button>
+  </form>
+  <a href="index.html" class="btn">Voltar</a>
+</body>
+</html>

--- a/profissional/index.html
+++ b/profissional/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profissional - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleLogin(event) {
+      event.preventDefault();
+      alert('Login de profissional - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Área da Profissional</h1>
+  <form onsubmit="handleLogin(event)">
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required>
+    <button type="submit" class="btn">Entrar</button>
+  </form>
+  <p>Primeira vez por aqui?</p>
+  <a href="cadastro.html" class="btn">Cadastrar</a>
+  <br>
+  <a href="../" class="btn">Início</a>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  background: #fff0f6;
+  color: #333;
+  margin: 0;
+  padding: 45px;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 20px;
+}
+
+.btn {
+  display: inline-block;
+  margin: 15px;
+  padding: 15px 30px;
+  font-size: 1.2rem;
+  border-radius: 12px;
+  text-decoration: none;
+  background: #ff69b4;
+  color: white;
+  transition: 0.3s;
+}
+
+.btn:hover {
+  background: #ff85c1;
+}
+
+form {
+  margin: 20px auto;
+  max-width: 300px;
+  text-align: left;
+}
+
+label {
+  display: block;
+  margin: 10px 0 5px;
+}
+
+input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- extract shared style sheet for consistent look
- add client login and registration pages with placeholder handlers
- add professional login and registration pages with placeholder handlers

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/nailnow-site/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68ba3f52cff0833388b79afd636e3b13