### PR TITLE
Add candy-colored landing page with map-style search

### DIFF
--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cadastro Cliente - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleSignup(event) {
+      event.preventDefault();
+      alert('Cadastro de cliente - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Cadastro de Cliente</h1>
+  <form onsubmit="handleSignup(event)">
+    <label for="nome">Nome</label>
+    <input type="text" id="nome" required>
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required>
+    <button type="submit" class="btn">Salvar</button>
+  </form>
+  <a href="index.html" class="btn">Voltar</a>
+</body>
+</html>

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cliente - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleLogin(event) {
+      event.preventDefault();
+      alert('Login de cliente - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Área da Cliente</h1>
+  <form onsubmit="handleLogin(event)">
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="password">Senha</label>
+    <input type="password" id="password" required>
+    <button type="submit" class="btn">Entrar</button>
+  </form>
+  <p>Ainda não tem conta?</p>
+  <a href="cadastro.html" class="btn">Cadastrar</a>
+  <br>
+  <a href="../" class="btn">Início</a>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,35 +4,25 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>NailNow 💅</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      text-align: center;
-      background: #fff0f6;
-      color: #333;
-      margin: 0;
-      padding: 45px;
-    }
-    h1 { font-size: 2.5rem; margin-bottom: 20px; }
-    .btn {
-      display: inline-block;
-      margin: 15px;
-      padding: 15px 30px;
-      font-size: 1.2rem;
-      border-radius: 12px;
-      text-decoration: none;
-      background: #ff69b4;
-      color: white;
-      transition: 0.3s;
-    }
-    .btn:hover { background: #ff85c1; }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Bem-vinda ao NailNow 💅</h1>
-  <p>Encontre manicures perto de você — rápido e fácil.</p>
-  
-  <a href="./cliente/" class="btn">Sou Cliente</a>
-  <a href="./profissional/" class="btn">Sou Profissional</a>
+  <header class="hero">
+    <h1>NailNow 💅</h1>
+    <p>Cuide das suas unhas sem sair de casa</p>
+    <div class="search-bar">
+      <span>📍</span>
+      <input type="text" placeholder="Digite seu endereço">
+      <button>Buscar</button>
+    </div>
+    <div class="actions">
+      <a href="./cliente/" class="btn">Sou Cliente</a>
+      <a href="./profissional/" class="btn secondary">Sou Profissional</a>
+    </div>
+  </header>
+  <section class="features">
+    <h2>Facilidade e conforto</h2>
+    <p>Com o NailNow, você encontra manicures de confiança e agenda um atendimento no conforto da sua casa.</p>
+  </section>
 </body>
 </html>

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cadastro Profissional - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleSignup(event) {
+      event.preventDefault();
+      alert('Cadastro de profissional - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Cadastro de Profissional</h1>
+  <form onsubmit="handleSignup(event)">
+    <label for="nome">Nome</label>
+    <input type="text" id="nome" required>
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="cidade">Cidade</label>
+    <input type="text" id="cidade" required>
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required>
+    <button type="submit" class="btn">Salvar</button>
+  </form>
+  <a href="index.html" class="btn">Voltar</a>
+</body>
+</html>

--- a/profissional/index.html
+++ b/profissional/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profissional - NailNow</title>
+  <link rel="stylesheet" href="../styles.css">
+  <script>
+    function handleLogin(event) {
+      event.preventDefault();
+      alert('Login de profissional - integração com Firebase em breve.');
+    }
+  </script>
+</head>
+<body>
+  <h1>Área da Profissional</h1>
+  <form onsubmit="handleLogin(event)">
+    <label for="email">Email</label>
+    <input type="email" id="email" required>
+    <label for="senha">Senha</label>
+    <input type="password" id="senha" required>
+    <button type="submit" class="btn">Entrar</button>
+  </form>
+  <p>Primeira vez por aqui?</p>
+  <a href="cadastro.html" class="btn">Cadastrar</a>
+  <br>
+  <a href="../" class="btn">Início</a>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,135 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap');
+
+:root {
+  --pink: #ff9ac8;
+  --pink-dark: #ff7ab8;
+  --blue: #9ad4f5;
+  --gray: #555;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  margin: 0;
+  color: var(--gray);
+  background: linear-gradient(135deg, #ffe6fa, #e0f7ff);
+  text-align: center;
+}
+
+h1, h2 {
+  margin: 0;
+}
+
+.hero {
+  text-align: center;
+  padding: 80px 20px;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  color: var(--pink-dark);
+  margin-bottom: 10px;
+}
+
+.hero p {
+  font-size: 1.2rem;
+  margin-bottom: 20px;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  max-width: 400px;
+  margin: 20px auto;
+  background: #fff;
+  border-radius: 40px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+  overflow: hidden;
+}
+
+.search-bar span {
+  padding-left: 15px;
+}
+
+.search-bar input {
+  flex: 1;
+  border: none;
+  padding: 12px;
+  font-size: 1rem;
+}
+
+.search-bar input:focus {
+  outline: none;
+}
+
+.search-bar button {
+  background: var(--pink-dark);
+  color: #fff;
+  border: none;
+  padding: 12px 25px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.search-bar button:hover {
+  background: var(--pink);
+}
+
+.actions {
+  margin-top: 30px;
+}
+
+.btn {
+  display: inline-block;
+  margin: 10px;
+  padding: 15px 30px;
+  font-size: 1.1rem;
+  border-radius: 30px;
+  text-decoration: none;
+  background: var(--pink-dark);
+  color: #fff;
+  transition: 0.3s;
+}
+
+.btn:hover {
+  background: var(--pink);
+}
+
+.btn.secondary {
+  background: var(--blue);
+}
+
+.btn.secondary:hover {
+  background: #b9e3fb;
+}
+
+.features {
+  background: #fff;
+  border-radius: 20px;
+  max-width: 700px;
+  margin: 60px auto;
+  padding: 40px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+  text-align: center;
+}
+
+form {
+  margin: 20px auto;
+  max-width: 320px;
+  text-align: left;
+  background: #fff;
+  padding: 30px;
+  border-radius: 20px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+}
+
+label {
+  display: block;
+  margin: 10px 0 5px;
+}
+
+input {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- redesign landing page with pastel theme and hero section
- add map-like search bar and feature callout about at-home service
- centralize styling in new Poppins-based candy color palette

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ba3f52cff0833388b79afd636e3b13