### PR TITLE
feat: add candy color design and navigation

### DIFF
--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -1,28 +1,51 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cadastro Cliente - NailNow</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script>
-    function handleSignup(event) {
-      event.preventDefault();
-      alert('Cadastro de cliente - integração com Firebase em breve.');
-    }
-  </script>
-</head>
-<body>
-  <h1>Cadastro de Cliente</h1>
-  <form onsubmit="handleSignup(event)">
-    <label for="nome">Nome</label>
-    <input type="text" id="nome" required>
-    <label for="email">Email</label>
-    <input type="email" id="email" required>
-    <label for="senha">Senha</label>
-    <input type="password" id="senha" required>
-    <button type="submit" class="btn">Salvar</button>
-  </form>
-  <a href="index.html" class="btn">Voltar</a>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cadastro Cliente - NailNow</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script>
+      function handleSignup(event) {
+        event.preventDefault();
+        alert("Cadastro de cliente - integração com Firebase em breve.");
+      }
+    </script>
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <div class="logo"><a href="../">NailNow 💅</a></div>
+        <ul class="nav-links">
+          <li><a href="../">Início</a></li>
+          <li><a href="../cliente/">Cliente</a></li>
+          <li><a href="../profissional/">Profissional</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <img
+        src="https://images.unsplash.com/photo-1583316174743-63f86d0d77d1?auto=format&fit=crop&w=800&q=80"
+        alt="Cliente fazendo as unhas"
+        class="page-img"
+      />
+      <h1>Cadastro de Cliente</h1>
+      <form onsubmit="handleSignup(event)">
+        <label for="nome">Nome</label>
+        <input type="text" id="nome" required />
+        <label for="email">Email</label>
+        <input type="email" id="email" required />
+        <label for="senha">Senha</label>
+        <input type="password" id="senha" required />
+        <button type="submit" class="btn">Salvar</button>
+      </form>
+      <a href="index.html" class="btn">Voltar</a>
+    </main>
+  </body>
 </html>

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -1,29 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cliente - NailNow</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script>
-    function handleLogin(event) {
-      event.preventDefault();
-      alert('Login de cliente - integração com Firebase em breve.');
-    }
-  </script>
-</head>
-<body>
-  <h1>Área da Cliente</h1>
-  <form onsubmit="handleLogin(event)">
-    <label for="email">Email</label>
-    <input type="email" id="email" required>
-    <label for="password">Senha</label>
-    <input type="password" id="password" required>
-    <button type="submit" class="btn">Entrar</button>
-  </form>
-  <p>Ainda não tem conta?</p>
-  <a href="cadastro.html" class="btn">Cadastrar</a>
-  <br>
-  <a href="../" class="btn">Início</a>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cliente - NailNow</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script>
+      function handleLogin(event) {
+        event.preventDefault();
+        alert("Login de cliente - integração com Firebase em breve.");
+      }
+    </script>
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <div class="logo"><a href="../">NailNow 💅</a></div>
+        <ul class="nav-links">
+          <li><a href="../">Início</a></li>
+          <li><a href="../cliente/">Cliente</a></li>
+          <li><a href="../profissional/">Profissional</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <img
+        src="https://images.unsplash.com/photo-1608339404861-7e16176f7591?auto=format&fit=crop&w=800&q=80"
+        alt="Clientes felizes com unhas feitas"
+        class="page-img"
+      />
+      <h1>Área da Cliente</h1>
+      <form onsubmit="handleLogin(event)">
+        <label for="email">Email</label>
+        <input type="email" id="email" required />
+        <label for="password">Senha</label>
+        <input type="password" id="password" required />
+        <button type="submit" class="btn">Entrar</button>
+      </form>
+      <p>Ainda não tem conta?</p>
+      <a href="cadastro.html" class="btn">Cadastrar</a>
+    </main>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,16 +1,42 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NailNow 💅</title>
-  <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-  <h1>Bem-vinda ao NailNow 💅</h1>
-  <p>Encontre manicures perto de você — rápido e fácil.</p>
-  
-  <a href="./cliente/" class="btn">Sou Cliente</a>
-  <a href="./profissional/" class="btn">Sou Profissional</a>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NailNow 💅</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <div class="logo"><a href="./">NailNow 💅</a></div>
+        <ul class="nav-links">
+          <li><a href="./">Início</a></li>
+          <li><a href="cliente/">Cliente</a></li>
+          <li><a href="profissional/">Profissional</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <img
+          src="https://images.unsplash.com/photo-1584447146176-d9a5cd208414?auto=format&fit=crop&w=1200&q=80"
+          alt="Arte de unhas coloridas"
+          class="hero-img"
+        />
+        <h1>Bem-vinda ao NailNow 💅</h1>
+        <p>Encontre manicures perto de você — rápido e fácil.</p>
+        <div class="cta">
+          <a href="cliente/" class="btn">Sou Cliente</a>
+          <a href="profissional/" class="btn">Sou Profissional</a>
+        </div>
+      </section>
+    </main>
+  </body>
 </html>

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -1,30 +1,53 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cadastro Profissional - NailNow</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script>
-    function handleSignup(event) {
-      event.preventDefault();
-      alert('Cadastro de profissional - integração com Firebase em breve.');
-    }
-  </script>
-</head>
-<body>
-  <h1>Cadastro de Profissional</h1>
-  <form onsubmit="handleSignup(event)">
-    <label for="nome">Nome</label>
-    <input type="text" id="nome" required>
-    <label for="email">Email</label>
-    <input type="email" id="email" required>
-    <label for="cidade">Cidade</label>
-    <input type="text" id="cidade" required>
-    <label for="senha">Senha</label>
-    <input type="password" id="senha" required>
-    <button type="submit" class="btn">Salvar</button>
-  </form>
-  <a href="index.html" class="btn">Voltar</a>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cadastro Profissional - NailNow</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script>
+      function handleSignup(event) {
+        event.preventDefault();
+        alert("Cadastro de profissional - integração com Firebase em breve.");
+      }
+    </script>
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <div class="logo"><a href="../">NailNow 💅</a></div>
+        <ul class="nav-links">
+          <li><a href="../">Início</a></li>
+          <li><a href="../cliente/">Cliente</a></li>
+          <li><a href="../profissional/">Profissional</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <img
+        src="https://images.unsplash.com/photo-1603808033192-1c0d1ba47188?auto=format&fit=crop&w=800&q=80"
+        alt="Ferramentas de manicure"
+        class="page-img"
+      />
+      <h1>Cadastro de Profissional</h1>
+      <form onsubmit="handleSignup(event)">
+        <label for="nome">Nome</label>
+        <input type="text" id="nome" required />
+        <label for="email">Email</label>
+        <input type="email" id="email" required />
+        <label for="cidade">Cidade</label>
+        <input type="text" id="cidade" required />
+        <label for="senha">Senha</label>
+        <input type="password" id="senha" required />
+        <button type="submit" class="btn">Salvar</button>
+      </form>
+      <a href="index.html" class="btn">Voltar</a>
+    </main>
+  </body>
 </html>

--- a/profissional/index.html
+++ b/profissional/index.html
@@ -1,29 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="pt-BR">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Profissional - NailNow</title>
-  <link rel="stylesheet" href="../styles.css">
-  <script>
-    function handleLogin(event) {
-      event.preventDefault();
-      alert('Login de profissional - integração com Firebase em breve.');
-    }
-  </script>
-</head>
-<body>
-  <h1>Área da Profissional</h1>
-  <form onsubmit="handleLogin(event)">
-    <label for="email">Email</label>
-    <input type="email" id="email" required>
-    <label for="senha">Senha</label>
-    <input type="password" id="senha" required>
-    <button type="submit" class="btn">Entrar</button>
-  </form>
-  <p>Primeira vez por aqui?</p>
-  <a href="cadastro.html" class="btn">Cadastrar</a>
-  <br>
-  <a href="../" class="btn">Início</a>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Profissional - NailNow</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script>
+      function handleLogin(event) {
+        event.preventDefault();
+        alert("Login de profissional - integração com Firebase em breve.");
+      }
+    </script>
+  </head>
+  <body>
+    <header>
+      <nav class="navbar">
+        <div class="logo"><a href="../">NailNow 💅</a></div>
+        <ul class="nav-links">
+          <li><a href="../">Início</a></li>
+          <li><a href="../cliente/">Cliente</a></li>
+          <li><a href="../profissional/">Profissional</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="page-content">
+      <img
+        src="https://images.unsplash.com/photo-1522336572468-97b06e8ef143?auto=format&fit=crop&w=800&q=80"
+        alt="Profissional cuidando das unhas"
+        class="page-img"
+      />
+      <h1>Área da Profissional</h1>
+      <form onsubmit="handleLogin(event)">
+        <label for="email">Email</label>
+        <input type="email" id="email" required />
+        <label for="senha">Senha</label>
+        <input type="password" id="senha" required />
+        <button type="submit" class="btn">Entrar</button>
+      </form>
+      <p>Primeira vez por aqui?</p>
+      <a href="cadastro.html" class="btn">Cadastrar</a>
+    </main>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,103 @@
+:root {
+  --pink: #ffafcc;
+  --light-pink: #ffc8dd;
+  --lavender: #cdb4db;
+  --light-blue: #bde0fe;
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: "Poppins", sans-serif;
   text-align: center;
-  background: #fff0f6;
+  background: linear-gradient(
+    135deg,
+    var(--pink),
+    var(--light-pink),
+    var(--light-blue),
+    var(--lavender)
+  );
   color: #333;
   margin: 0;
-  padding: 45px;
+  padding: 0;
+  min-height: 100vh;
+}
+
+header {
+  background: var(--pink);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.navbar {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+}
+
+.logo {
+  font-size: 1.5rem;
+  color: #fff;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.logo a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.nav-links li {
+  margin-left: 20px;
+}
+
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-size: 1rem;
+  transition: opacity 0.3s;
+}
+
+.nav-links a:hover {
+  opacity: 0.8;
+}
+
+.hero {
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 20px;
+}
+
+.hero-img {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border-radius: 16px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 30px;
+}
+
+.page-content {
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 20px;
+}
+
+.page-img {
+  width: 100%;
+  max-width: 500px;
+  height: auto;
+  border-radius: 16px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin: 0 auto 30px;
+  display: block;
 }
 
 h1 {
@@ -19,19 +112,28 @@ h1 {
   font-size: 1.2rem;
   border-radius: 12px;
   text-decoration: none;
-  background: #ff69b4;
+  background: var(--lavender);
   color: white;
-  transition: 0.3s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
 }
 
 .btn:hover {
-  background: #ff85c1;
+  background: var(--light-pink);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
 }
 
 form {
   margin: 20px auto;
   max-width: 300px;
   text-align: left;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 label {


### PR DESCRIPTION
## Summary
- add responsive navigation bar and hero section with image
- introduce candy-color theme with new stylesheet
- enhance client and professional pages with decorative images

## Testing
- `npx prettier --check index.html cliente/index.html cliente/cadastro.html profissional/index.html profissional/cadastro.html styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68bae8a5fa2c8333b921ddad2b6416cb