### PR TITLE
feat: add services menu and platform overview

### DIFF
--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -6,7 +6,7 @@
     <title>Cadastro Cliente - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../styles.css" />
@@ -23,6 +23,8 @@
         <div class="logo"><a href="../">NAILNOW 💅</a></div>
         <ul class="nav-links">
           <li><a href="../">Início</a></li>
+          <li><a href="../#servicos">Serviços</a></li>
+          <li><a href="../#como-funciona">Como Funciona</a></li>
           <li><a href="../cliente/">Cliente</a></li>
           <li><a href="../profissional/">Profissional</a></li>
         </ul>

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -6,7 +6,7 @@
     <title>Cliente - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../styles.css" />
@@ -23,6 +23,8 @@
         <div class="logo"><a href="../">NAILNOW 💅</a></div>
         <ul class="nav-links">
           <li><a href="../">Início</a></li>
+          <li><a href="../#servicos">Serviços</a></li>
+          <li><a href="../#como-funciona">Como Funciona</a></li>
           <li><a href="../cliente/">Cliente</a></li>
           <li><a href="../profissional/">Profissional</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>NailNow 💅</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
@@ -17,6 +17,8 @@
         <div class="logo"><a href="./">NAILNOW 💅</a></div>
         <ul class="nav-links">
           <li><a href="./">Início</a></li>
+          <li><a href="#servicos">Serviços</a></li>
+          <li><a href="#como-funciona">Como Funciona</a></li>
           <li><a href="cliente/">Cliente</a></li>
           <li><a href="profissional/">Profissional</a></li>
         </ul>
@@ -36,6 +38,27 @@
           <a href="cliente/" class="btn">Sou Cliente</a>
           <a href="profissional/" class="btn">Sou Profissional</a>
         </div>
+      </section>
+
+      <section id="servicos" class="services">
+        <h2>Nossos Serviços</h2>
+        <ul class="services-list">
+          <li>Manicure tradicional</li>
+          <li>Pedicure tradicional</li>
+          <li>Esmaltação gel</li>
+        </ul>
+      </section>
+
+      <section id="como-funciona" class="about">
+        <h2>Como Funciona</h2>
+        <p>
+          1. Resumo Executivo — A NailNow é uma plataforma inovadora que conecta
+          clientes a manicures e pedicures profissionais para serviços em
+          domicílio. Inspirado no modelo "Uber", o aplicativo permite que
+          usuárias encontrem e agendem serviços de unha de forma rápida, segura
+          e conveniente. O pagamento é realizado diretamente pela plataforma,
+          garantindo segurança e comodidade para ambas as partes.
+        </p>
       </section>
     </main>
   </body>

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -6,7 +6,7 @@
     <title>Cadastro Profissional - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../styles.css" />
@@ -23,6 +23,8 @@
         <div class="logo"><a href="../">NAILNOW 💅</a></div>
         <ul class="nav-links">
           <li><a href="../">Início</a></li>
+          <li><a href="../#servicos">Serviços</a></li>
+          <li><a href="../#como-funciona">Como Funciona</a></li>
           <li><a href="../cliente/">Cliente</a></li>
           <li><a href="../profissional/">Profissional</a></li>
         </ul>

--- a/profissional/index.html
+++ b/profissional/index.html
@@ -6,7 +6,7 @@
     <title>Profissional - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="../styles.css" />
@@ -23,6 +23,8 @@
         <div class="logo"><a href="../">NAILNOW 💅</a></div>
         <ul class="nav-links">
           <li><a href="../">Início</a></li>
+          <li><a href="../#servicos">Serviços</a></li>
+          <li><a href="../#como-funciona">Como Funciona</a></li>
           <li><a href="../cliente/">Cliente</a></li>
           <li><a href="../profissional/">Profissional</a></li>
         </ul>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,12 @@
-
+/* Brand theme inspired by modern beauty labels */
+:root {
+  --brand-bg: #fdfcfb;
+  --brand-text: #111111;
+  --accent: #e26d9b;
+}
 
 body {
-  font-family: "Playfair Display", serif;
+  font-family: "Inter", sans-serif;
   text-align: center;
   background: var(--brand-bg);
   color: var(--brand-text);
@@ -23,11 +28,11 @@ header {
   padding: 10px 20px;
 }
 
-
-
 .logo a {
   color: var(--brand-text);
   text-decoration: none;
+  font-family: "Playfair Display", serif;
+  font-weight: 700;
 }
 
 .nav-links {
@@ -45,11 +50,11 @@ header {
   color: var(--brand-text);
   text-decoration: none;
   font-size: 1rem;
-  transition: opacity 0.3s;
+  transition: color 0.3s;
 }
 
 .nav-links a:hover {
-  opacity: 0.8;
+  color: var(--accent);
 }
 
 .hero {
@@ -84,8 +89,16 @@ header {
 }
 
 h1 {
+  font-family: "Playfair Display", serif;
   font-size: 2.5rem;
   margin-bottom: 20px;
+  text-transform: uppercase;
+}
+
+h2 {
+  font-family: "Playfair Display", serif;
+  font-size: 2rem;
+  margin: 40px 0 20px;
   text-transform: uppercase;
 }
 
@@ -96,16 +109,17 @@ h1 {
   font-size: 1.2rem;
   border-radius: 12px;
   text-decoration: none;
-  background: var(--brand-text);
+  background: var(--accent);
   color: var(--brand-bg);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition:
+    background 0.3s,
     transform 0.2s,
     box-shadow 0.2s;
 }
 
 .btn:hover {
-  opacity: 0.9;
+  background: var(--brand-text);
   transform: translateY(-2px);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
 }
@@ -117,6 +131,29 @@ form {
   background: rgba(255, 255, 255, 0.9);
   padding: 20px;
   border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.services,
+.about {
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 20px;
+}
+
+.services-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+
+.services-list li {
+  background: #fff;
+  border-radius: 12px;
+  padding: 15px 25px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
## Summary
- extend navigation with links to services and how-it-works sections
- introduce service list and platform overview on landing page
- style new sections for a polished, modern feel

## Testing
- `npx prettier --check index.html cliente/index.html cliente/cadastro.html profissional/index.html profissional/cadastro.html styles.css`

------
https://chatgpt.com/codex/tasks/task_e_68c2c05e140c833393a86087fc491655