### PR TITLE
feat: redesign landing with rose gold theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div class="top-bar">Frete grátis em pedidos acima de R$80</div>
     <header>
       <nav class="navbar">
         <div class="logo"><a href="./">NAILNOW 💅</a></div>
@@ -27,17 +28,31 @@
 
     <main>
       <section class="hero">
-        <img
-          src="https://images.unsplash.com/photo-1584447146176-d9a5cd208414?auto=format&fit=crop&w=1200&q=80"
-          alt="Arte de unhas coloridas"
-          class="hero-img"
-        />
-        <h1>Bem-vinda ao NailNow 💅</h1>
-        <p>Encontre manicures perto de você — rápido e fácil.</p>
-        <div class="cta">
-          <a href="cliente/" class="btn">Sou Cliente</a>
-          <a href="profissional/" class="btn">Sou Profissional</a>
+        <div class="hero-text">
+          <span class="tag">Novo</span>
+          <h1>Coleção chegou agora</h1>
+          <p>Encontre manicures perto de você — rápido e fácil.</p>
+          <div class="cta">
+            <a href="cliente/" class="btn">Sou Cliente</a>
+            <a href="profissional/" class="btn">Sou Profissional</a>
+          </div>
         </div>
+        <div class="hero-media">
+          <img
+            src="https://images.unsplash.com/photo-1584447146176-d9a5cd208414?auto=format&fit=crop&w=1200&q=80"
+            alt="Arte de unhas coloridas"
+            class="hero-img"
+          />
+        </div>
+      </section>
+
+      <section class="signup">
+        <h2>Assine</h2>
+        <p>Seja a primeira a saber sobre novos produtos e ofertas exclusivas</p>
+        <form class="signup-form">
+          <input type="email" placeholder="email" />
+          <button class="btn">Inscrever-se</button>
+        </form>
       </section>
 
       <section id="servicos" class="services">

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,27 @@
 /* Brand theme inspired by modern beauty labels */
 :root {
-  --brand-bg: #fdfcfb;
-  --brand-text: #111111;
-  --accent: #e26d9b;
+  --brand-bg: #fff9f9;
+  --brand-bg-alt: #fbe5e8;
+  --brand-text: #3c3030;
+  --brand-accent: #e26d9b;
 }
 
 body {
   font-family: "Inter", sans-serif;
   text-align: center;
-  background: var(--brand-bg);
+  background: linear-gradient(180deg, var(--brand-bg), var(--brand-bg-alt));
   color: var(--brand-text);
   margin: 0;
   padding: 0;
   min-height: 100vh;
+}
+
+.top-bar {
+  background: var(--brand-bg-alt);
+  text-align: center;
+  font-size: 0.875rem;
+  padding: 8px 0;
+  color: var(--brand-text);
 }
 
 header {
@@ -20,12 +29,12 @@ header {
 }
 
 .navbar {
-  max-width: 900px;
+  max-width: 1200px;
   margin: 0 auto;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
+  padding: 20px 40px;
 }
 
 .logo a {
@@ -54,22 +63,69 @@ header {
 }
 
 .nav-links a:hover {
-  color: var(--accent);
+  color: var(--brand-accent);
 }
 
 .hero {
-  max-width: 900px;
-  margin: 40px auto;
+  max-width: 1200px;
+  margin: 60px auto;
   padding: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+}
+
+.hero-text {
+  flex: 1;
+  text-align: left;
+}
+
+.hero-text h1 {
+  font-size: 3rem;
+  margin: 20px 0;
+}
+
+.hero-text p {
+  font-size: 1.125rem;
+  margin-bottom: 20px;
+}
+
+.tag {
+  display: inline-block;
+  background: var(--brand-accent);
+  color: var(--brand-bg);
+  padding: 4px 12px;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+}
+
+.hero-media {
+  flex: 1;
 }
 
 .hero-img {
   width: 100%;
-  max-height: 400px;
+  border-top-left-radius: 200px;
+  border-top-right-radius: 200px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
   object-fit: cover;
-  border-radius: 16px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  margin-bottom: 30px;
+}
+
+.cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.hero-text .cta {
+  justify-content: flex-start;
 }
 
 .page-content {
@@ -105,13 +161,15 @@ h2 {
 .btn {
   display: inline-block;
   margin: 15px;
-  padding: 15px 30px;
-  font-size: 1.2rem;
-  border-radius: 12px;
+  padding: 12px 30px;
+  font-size: 1rem;
+  border-radius: 30px;
   text-decoration: none;
-  background: var(--accent);
+  background: var(--brand-accent);
   color: var(--brand-bg);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-transform: uppercase;
+  letter-spacing: 1px;
   transition:
     background 0.3s,
     transform 0.2s,
@@ -124,7 +182,7 @@ h2 {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
 }
 
-form {
+form:not(.signup-form) {
   margin: 20px auto;
   max-width: 300px;
   text-align: left;
@@ -132,6 +190,36 @@ form {
   padding: 20px;
   border-radius: 12px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.signup {
+  background: var(--brand-bg-alt);
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.signup h2 {
+  font-family: "Playfair Display", serif;
+  font-size: 2rem;
+  text-transform: uppercase;
+}
+
+.signup-form {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+.signup-form input {
+  padding: 12px 16px;
+  border-radius: 30px;
+  border: 1px solid #ccc;
+  min-width: 250px;
+}
+
+.signup-form .btn {
+  margin: 0;
 }
 
 .services,


### PR DESCRIPTION
## Summary
- add free-shipping top bar and rose-gold gradient background
- split hero into text and media columns and add tag styling
- introduce newsletter signup section with pill-shaped inputs

## Testing
- `npx --yes prettier@3.2.5 --write index.html styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68c33a15cab08333843fa44543067d7e