### PR TITLE
Add meta descriptions to HTML pages

### DIFF
--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Formulário de cadastro de cliente para agendar serviços de unha pela plataforma NailNow."
+    />
     <title>Cadastro Cliente - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Área da cliente da NailNow para login e acesso rápido aos serviços de manicure e pedicure."
+    />
     <title>Cliente - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="NailNow conecta clientes a manicures e pedicures para agendamentos rápidos e práticos."
+    />
     <title>NailNow 💅</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Formulário de cadastro de profissional para manicures oferecerem serviços de unha na plataforma NailNow."
+    />
     <title>Cadastro Profissional - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link

--- a/profissional/index.html
+++ b/profissional/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Área da profissional da NailNow para manicures acessarem suas contas e atender clientes."
+    />
     <title>Profissional - NailNow</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link


### PR DESCRIPTION
## Summary
- add SEO-friendly meta descriptions to main, client, and professional pages

## Testing
- `npx --yes prettier@3.2.5 --write index.html cliente/index.html cliente/cadastro.html profissional/index.html profissional/cadastro.html`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3824824148333bcf7e681b2f6d19c