### PR TITLE
Refine homepage for NailNow experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Rose Gold is the destination for luminous beauty essentials and elevated self-care rituals."
+      content="NailNow conecta clientes e manicures profissionais com agendamentos rápidos, avaliações reais e atendimento onde você estiver."
     />
-    <title>Rose Gold | Modern Beauty Boutique</title>
+    <title>NailNow | Beleza nas suas mãos</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,116 +17,181 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Free shipping on orders over $50</div>
+    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
     <header class="site-header">
-      <div class="header-row header-row--top">
-        <button type="button" class="icon-button" aria-label="Search">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M10.5 3a7.5 7.5 0 0 1 5.934 12.123l3.222 3.221a1 1 0 0 1-1.414 1.415l-3.222-3.222A7.5 7.5 0 1 1 10.5 3zm0 2a5.5 5.5 0 1 0 0 11a5.5 5.5 0 0 0 0-11z"
-              fill="currentColor"
-            />
-          </svg>
-        </button>
-        <a href="./" class="brand-mark" aria-label="Rose Gold home"
-          >Rose Gold</a
-        >
-        <div class="header-actions">
-          <button type="button" class="icon-button" aria-label="Account">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M12 3a5 5 0 1 1 0 10a5 5 0 0 1 0-10zm0 12c4.418 0 8 2.239 8 5v1a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1c0-2.761 3.582-5 8-5z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-          <button type="button" class="icon-button" aria-label="Shopping cart">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M7 4a1 1 0 0 1 .98.804L8.382 7H20a1 1 0 0 1 .986 1.164l-1.5 9A1 1 0 0 1 18.5 18H8a1 1 0 0 1-.98-.804L5.618 6H4a1 1 0 1 1 0-2h3zm2.486 5l.933 7h7.217l1.167-7H9.486zM9 20.5A1.5 1.5 0 1 1 6 20.5A1.5 1.5 0 0 1 9 20.5zm10 0A1.5 1.5 0 1 1 16 20.5A1.5 1.5 0 0 1 19 20.5z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </div>
+      <div class="header-inner">
+        <a href="./" class="brand-mark" aria-label="Início da NailNow">NailNow 💅</a>
+        <nav class="primary-nav" aria-label="Principal">
+          <a href="#clientes" class="nav-link">Sou cliente</a>
+          <a href="profissional/" class="nav-link">Sou profissional</a>
+          <a href="#como-funciona" class="nav-link">Como funciona</a>
+          <a href="#experiencias" class="nav-link">Experiências</a>
+        </nav>
+        <a href="profissional/" class="btn btn--outline">Quero atender pela NailNow</a>
       </div>
-      <nav class="header-row header-row--nav" aria-label="Primary">
-        <a href="./" class="nav-link">Home</a>
-        <a href="#about" class="nav-link">About</a>
-        <a href="#shop" class="nav-link">Shop</a>
-        <a href="#blog" class="nav-link">Blog</a>
-        <a href="#contact" class="nav-link">Contact</a>
-      </nav>
     </header>
 
     <main>
-      <section class="hero">
+      <section id="clientes" class="hero">
+        <div class="hero-copy">
+          <span class="hero-label">Para clientes</span>
+          <h1>Unhas impecáveis sem sair de casa</h1>
+          <p>
+            Encontre manicures avaliadas pela comunidade, escolha o melhor horário e receba o atendimento com segurança e praticidade.
+          </p>
+          <div class="hero-actions">
+            <a href="cliente/" class="btn">Agendar agora</a>
+            <a href="#como-funciona" class="link-underlined">Ver como funciona</a>
+          </div>
+          <div class="hero-highlights">
+            <div class="highlight-card">
+              <strong>Agenda inteligente</strong>
+              <span>Confirme em segundos sem mensagens infinitas.</span>
+            </div>
+            <div class="highlight-card">
+              <strong>Pagamento seguro</strong>
+              <span>Transações protegidas e recibo instantâneo.</span>
+            </div>
+            <div class="highlight-card">
+              <strong>Avaliações reais</strong>
+              <span>Feedback de clientes verificados em cada serviço.</span>
+            </div>
+          </div>
+        </div>
         <div class="hero-media">
           <div class="hero-image-wrapper">
             <img
-              src="https://images.unsplash.com/photo-1612531386530-972ee8be467f?auto=format&fit=crop&w=900&q=80"
-              alt="Model showcasing the Rose Gold collection"
+              src="https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=900&q=80"
+              alt="Cliente sorrindo enquanto faz as unhas com uma manicure"
             />
           </div>
         </div>
-        <div class="hero-copy">
-          <span class="hero-label">NEW</span>
-          <h1>Collection just landed</h1>
-          <p>
-            Discover rose-infused finishes and satin touches designed to glow on
-            every skin tone.
-          </p>
-          <a href="#shop" class="btn">Shop Now</a>
+      </section>
+
+      <section class="metrics" aria-label="Indicadores da plataforma">
+        <div class="metric">
+          <span class="metric-number">+25 mil</span>
+          <span class="metric-label">agendamentos concluídos</span>
+        </div>
+        <div class="metric">
+          <span class="metric-number">98%</span>
+          <span class="metric-label">de satisfação das clientes</span>
+        </div>
+        <div class="metric">
+          <span class="metric-number">+200</span>
+          <span class="metric-label">profissionais verificadas</span>
+        </div>
+        <div class="metric">
+          <span class="metric-number">10 cidades</span>
+          <span class="metric-label">com cobertura NailNow</span>
         </div>
       </section>
 
+      <section id="como-funciona" class="flow">
+        <div class="section-heading">
+          <span class="eyebrow">Passo a passo</span>
+          <h2>Como funciona a NailNow</h2>
+          <p>
+            Do agendamento ao pagamento, cuidamos de tudo para você relaxar e aproveitar o momento.
+          </p>
+        </div>
+        <ol class="flow-steps">
+          <li>
+            <h3>Escolha o serviço perfeito</h3>
+            <p>Selecione manicure, pedicure, spa dos pés e outras combinações criadas por especialistas.</p>
+          </li>
+          <li>
+            <h3>Defina horário e local</h3>
+            <p>Informe onde quer ser atendida e encontre horários flexíveis com profissionais próximas.</p>
+          </li>
+          <li>
+            <h3>Confirme e acompanhe</h3>
+            <p>Receba notificações, acompanhe o deslocamento e avalie sua experiência direto pelo app.</p>
+          </li>
+        </ol>
+      </section>
+
+      <section id="experiencias" class="experiences">
+        <div class="section-heading">
+          <span class="eyebrow">Experiências reais</span>
+          <h2>Histórias de quem já é NailNow</h2>
+          <p>Veja como a beleza em casa transformou a rotina de clientes em várias cidades.</p>
+        </div>
+        <div class="experience-grid">
+          <article class="experience-card">
+            <p>
+              “Consigo agendar manicure e pedicure para mim e minha mãe sem conflitos de horário. Atendimento impecável!”
+            </p>
+            <span class="experience-author">Ana, São Paulo</span>
+          </article>
+          <article class="experience-card">
+            <p>
+              “As profissionais são super pontuais e trazem todos os materiais higienizados. Minha casa vira um spa.”
+            </p>
+            <span class="experience-author">Patrícia, Recife</span>
+          </article>
+          <article class="experience-card">
+            <p>
+              “Perfeito para quem trabalha em home office. Faço as unhas no intervalo do almoço e pago pelo app.”
+            </p>
+            <span class="experience-author">Luiza, Belo Horizonte</span>
+          </article>
+          <article class="experience-card">
+            <p>
+              “Já experimentei várias profissionais e todas têm avaliações transparentes. Me sinto segura em cada visita.”
+            </p>
+            <span class="experience-author">Camila, Curitiba</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="cta-profissional" id="profissionais">
+        <div class="cta-content">
+          <span class="eyebrow">Para manicures</span>
+          <h2>Atenda novas clientes com a NailNow</h2>
+          <p>
+            Cadastre-se gratuitamente, defina sua agenda, receba pagamentos com rapidez e tenha suporte em cada atendimento.
+          </p>
+        </div>
+        <a href="profissional/" class="btn btn--light">Quero fazer parte</a>
+      </section>
+
       <section class="newsletter">
-        <h2>SIGN UP</h2>
-        <p>Be the first to find out about new products and exclusive offers</p>
+        <h2>Receba novidades da NailNow</h2>
+        <p>
+          Fique por dentro do lançamento do aplicativo, benefícios exclusivos e dicas de autocuidado.
+        </p>
         <form>
           <input
             type="email"
-            placeholder="email"
-            aria-label="Email address"
+            placeholder="Seu melhor e-mail"
+            aria-label="Endereço de e-mail"
             required
           />
-          <button type="submit">submit</button>
+          <button type="submit">Quero receber</button>
         </form>
         <img src="gold-watermark.png" class="watermark" alt="" aria-hidden="true" />
       </section>
-
-      <section id="about" class="content-section">
-        <h2>About</h2>
-        <p>
-          Rose Gold celebrates self-expression through curated beauty rituals.
-          Our artisans obsess over the perfect pigment, the gentlest textures,
-          and the experience of luxe self-care at home.
-        </p>
-      </section>
-
-      <section id="shop" class="content-section">
-        <h2>Shop</h2>
-        <p>
-          Explore polishes, treatments, and signature accessories crafted to
-          inspire your next ritual.
-        </p>
-      </section>
-
-      <section id="blog" class="content-section">
-        <h2>Blog</h2>
-        <p>
-          Get inspired with tutorials, artist spotlights, and behind-the-scenes
-          stories from the studio.
-        </p>
-      </section>
-
-      <section id="contact" class="content-section">
-        <h2>Contact</h2>
-        <p>
-          We're here to help. Reach us at hello@rosegold.studio for bespoke
-          recommendations.
-        </p>
-      </section>
     </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <div>
+          <h2 class="footer-logo">NailNow 💅</h2>
+          <p>Beleza na sua agenda, com profissionais selecionadas e atendimento onde você estiver.</p>
+        </div>
+        <div class="footer-links">
+          <a href="cliente/">Área da cliente</a>
+          <a href="profissional/">Área da profissional</a>
+          <a href="#como-funciona">Como funciona</a>
+          <a href="#experiencias">Experiências</a>
+        </div>
+        <div class="footer-contact">
+          <a href="mailto:contato@nailnow.com">contato@nailnow.com</a>
+          <span>Atendimento de segunda a sábado, 8h às 20h.</span>
+        </div>
+      </div>
+      <p class="footer-copy">© NailNow 2024. Todos os direitos reservados.</p>
+    </footer>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -65,76 +65,46 @@ main {
 
 .site-header {
   background: var(--surface);
-  padding: 0 clamp(1.5rem, 6vw, 3.75rem);
+  padding: clamp(1rem, 2.5vw, 1.5rem) clamp(1.5rem, 6vw, 3.75rem);
   box-shadow: 0 24px 40px rgba(79, 39, 49, 0.08);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
-.header-row {
+.header-inner {
   display: flex;
   align-items: center;
-}
-
-.header-row--top {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: clamp(1rem, 2vw, 2.5rem);
-  padding: clamp(1rem, 2.5vw, 1.75rem) 0;
+  justify-content: space-between;
+  gap: clamp(1rem, 4vw, 2.5rem);
+  max-width: var(--max-width);
+  margin: 0 auto;
 }
 
 .brand-mark {
   font-family: "Playfair Display", serif;
   text-transform: uppercase;
   letter-spacing: 0.22em;
-  font-size: clamp(1.5rem, 3vw, 2.5rem);
-  text-align: center;
+  font-size: clamp(1.4rem, 3vw, 2.2rem);
   color: var(--deep-rose);
+  white-space: nowrap;
 }
 
-.header-actions {
+.primary-nav {
   display: flex;
   align-items: center;
-  gap: clamp(0.75rem, 2vw, 1.75rem);
-}
-
-.icon-button {
-  background: none;
-  border: none;
-  padding: 0.35rem;
-  display: inline-flex;
-  align-items: center;
+  gap: clamp(1rem, 3vw, 2rem);
+  flex-wrap: wrap;
   justify-content: center;
-  border-radius: 999px;
-  color: var(--text-main);
-  transition:
-    background-color 0.3s ease,
-    color 0.3s ease;
-  cursor: pointer;
-}
-
-.icon-button:hover {
-  background-color: rgba(199, 159, 86, 0.12);
-  color: var(--gold);
-}
-
-.icon-button svg {
-  width: 1.5rem;
-  height: 1.5rem;
-}
-
-.header-row--nav {
-  justify-content: center;
-  gap: clamp(1.25rem, 4vw, 3rem);
-  padding-bottom: clamp(1rem, 2.5vw, 1.75rem);
-  font-size: clamp(0.68rem, 1.3vw, 0.9rem);
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  font-weight: 600;
 }
 
 .nav-link {
   position: relative;
-  padding-bottom: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding-bottom: 0.35rem;
   transition: color 0.3s ease;
 }
 
@@ -160,6 +130,19 @@ main {
 .nav-link:focus::after {
   width: 100%;
   left: 0;
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--deep-rose);
+  border: 1px solid rgba(78, 43, 52, 0.25);
+  letter-spacing: 0.16em;
+}
+
+.btn--outline:hover {
+  background: var(--deep-rose);
+  color: #fff;
+  border-color: var(--deep-rose);
 }
 
 .hero {
@@ -258,6 +241,62 @@ main {
   color: var(--text-muted);
 }
 
+.hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.link-underlined {
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: relative;
+}
+
+.link-underlined::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.2rem;
+  width: 100%;
+  height: 2px;
+  background: rgba(78, 43, 52, 0.3);
+  transition: transform 0.3s ease;
+  transform-origin: left;
+}
+
+.link-underlined:hover::after,
+.link-underlined:focus::after {
+  transform: scaleX(0.8);
+}
+
+.hero-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.highlight-card {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 20px;
+  padding: 1.1rem 1.3rem;
+  box-shadow: 0 12px 24px rgba(79, 39, 49, 0.08);
+}
+
+.highlight-card strong {
+  display: block;
+  font-size: 1.05rem;
+  margin-bottom: 0.35rem;
+}
+
+.highlight-card span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -280,6 +319,172 @@ main {
   transform: translateY(-2px);
   background: var(--gold);
   border-color: rgba(199, 159, 86, 0.6);
+}
+
+.btn--light {
+  background: #fff;
+  color: var(--deep-rose);
+  border: 1px solid rgba(199, 159, 86, 0.4);
+}
+
+.btn--light:hover {
+  background: var(--gold);
+  color: #fff;
+  border-color: var(--gold);
+}
+
+.metrics {
+  max-width: var(--max-width);
+  margin: clamp(2rem, 8vw, 4rem) auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+}
+
+.metric {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  text-align: center;
+  box-shadow: 0 16px 32px rgba(79, 39, 49, 0.1);
+}
+
+.metric-number {
+  display: block;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  color: var(--deep-rose);
+  margin-bottom: 0.35rem;
+}
+
+.metric-label {
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.flow {
+  max-width: var(--max-width);
+  margin: clamp(3rem, 9vw, 6rem) auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+}
+
+.section-heading {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto clamp(2rem, 6vw, 3.5rem);
+}
+
+.section-heading h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 1rem;
+}
+
+.section-heading p {
+  color: var(--text-muted);
+}
+
+.eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--gold);
+  margin-bottom: 1rem;
+}
+
+.flow-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.flow-steps li {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: 0 18px 36px rgba(79, 39, 49, 0.08);
+}
+
+.flow-steps h3 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.3rem, 3vw, 1.8rem);
+  margin-bottom: 0.75rem;
+}
+
+.flow-steps p {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.experiences {
+  max-width: var(--max-width);
+  margin: clamp(3rem, 10vw, 6rem) auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+}
+
+.experience-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+}
+
+.experience-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 4vw, 2.4rem);
+  box-shadow: 0 20px 40px rgba(79, 39, 49, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.experience-card p {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-main);
+}
+
+.experience-author {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.cta-profissional {
+  max-width: var(--max-width);
+  margin: clamp(3rem, 10vw, 6rem) auto;
+  padding: clamp(2.5rem, 6vw, 3.5rem) clamp(1.5rem, 6vw, 3rem);
+  background: linear-gradient(135deg, rgba(78, 43, 52, 0.95), rgba(199, 159, 86, 0.85));
+  border-radius: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  color: #fff;
+  flex-wrap: wrap;
+}
+
+.cta-content {
+  max-width: 520px;
+}
+
+.cta-content h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 1rem;
+}
+
+.cta-content p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .newsletter {
@@ -368,32 +573,65 @@ main {
   pointer-events: none;
 }
 
-.content-section {
-  max-width: 820px;
-  margin: clamp(3rem, 10vw, 5rem) auto 0;
-  text-align: center;
-  padding: 0 clamp(1rem, 4vw, 2rem);
+.site-footer {
+  background: rgba(78, 43, 52, 0.95);
+  color: #fff;
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 6vw, 3.75rem);
 }
 
-.content-section h2 {
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto clamp(2rem, 6vw, 3rem);
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.footer-logo {
   font-family: "Playfair Display", serif;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  font-size: clamp(1.5rem, 2.5vw, 2rem);
   margin-bottom: 1rem;
 }
 
-.content-section p {
-  color: var(--text-muted);
+.footer-links,
+.footer-contact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer-links a,
+.footer-contact a {
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footer-links a:hover,
+.footer-links a:focus,
+.footer-contact a:hover,
+.footer-contact a:focus {
+  color: #fff;
+}
+
+.footer-contact span {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.footer-copy {
+  max-width: var(--max-width);
   margin: 0 auto;
+  text-align: center;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
 }
 
 @media (max-width: 960px) {
-  .header-row--nav {
-    flex-wrap: wrap;
-    gap: 1rem 1.5rem;
-  }
-
   .hero {
     flex-direction: column;
     text-align: center;
@@ -415,6 +653,15 @@ main {
     right: -120px;
     bottom: -140px;
   }
+
+  .hero-actions {
+    justify-content: center;
+  }
+
+  .cta-profissional {
+    text-align: center;
+    justify-content: center;
+  }
 }
 
 @media (max-width: 640px) {
@@ -424,34 +671,17 @@ main {
   }
 
   .site-header {
-    padding-inline: clamp(1rem, 6vw, 2.25rem);
+    padding: clamp(0.85rem, 6vw, 1.25rem) clamp(1rem, 6vw, 2.25rem);
   }
 
-  .header-row--top {
-    grid-template-columns: 1fr auto;
-    grid-template-areas:
-      "search brand"
-      "actions brand";
-    row-gap: 0.75rem;
-    justify-items: start;
+  .header-inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
   }
 
-  .header-row--top > .icon-button {
-    grid-area: search;
-  }
-
-  .brand-mark {
-    grid-area: brand;
-    justify-self: center;
-  }
-
-  .header-actions {
-    grid-area: actions;
-  }
-
-  .header-row--nav {
-    font-size: 0.65rem;
-    letter-spacing: 0.18em;
+  .primary-nav {
+    justify-content: center;
   }
 
   .hero {
@@ -473,5 +703,9 @@ main {
 
   .newsletter button {
     width: 100%;
+  }
+
+  .cta-profissional {
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- Rebrand the homepage head metadata, banner, and navigation for the NailNow Portuguese experience
- Replace the hero and subsequent sections with NailNow-focused highlights, metrics, flow, testimonials, CTA, and localized footer
- Extend the shared stylesheet with layouts for the new sections and responsive behaviors

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db3714e500833397670df2058833de