### PR TITLE
Remove redundant hero link from client CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
           </p>
           <div class="hero-actions">
             <a href="cliente/" class="btn">Agendar agora</a>
-            <a href="#como-funciona" class="link-underlined">Ver como funciona</a>
           </div>
           <div class="hero-highlights">
             <div class="highlight-card">


### PR DESCRIPTION
## Summary
- remove the secondary "Ver como funciona" link from the client hero call to action so only the primary booking button remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf7304c488333a8444cc07834352c