### PR TITLE
Add Quem somos link to footer navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
         <div class="footer-links">
           <a href="cliente/">Área da cliente</a>
           <a href="profissional/">Área da profissional</a>
+          <a href="#quem-somos">Quem somos nós</a>
         </div>
         <div class="footer-contact">
           <a href="mailto:contato@nailnow.com">contato@nailnow.com</a>


### PR DESCRIPTION
## Summary
- add a "Quem somos nós" link to the footer navigation for easier discovery of the about section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc0c518df48333ba2ff64d2c7f9c59