### PR TITLE
Add full Quem somos content section

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,55 @@
           aria-hidden="true"
         />
       </section>
+
+      <section id="quem-somos" class="about">
+        <h2>Quem somos?</h2>
+        <p>
+          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
+          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
+        </p>
+        <p>
+          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de
+          mudar o mundo.
+        </p>
+        <p>
+          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que
+          ser aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
+        </p>
+        <p>
+          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar
+          também a vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder
+          feminino se une, “sai da frente”!
+        </p>
+        <p>
+          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
+        </p>
+        <p>
+          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
+          para depois.
+        </p>
+        <p>
+          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
+          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse
+          os dois mundos, de forma justa, moderna e eficiente.
+        </p>
+        <p>
+          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em
+          nós, tiramos de letra.
+        </p>
+        <p>
+          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres
+          empoderadas, lindas, livres e que não têm tempo a perder.
+        </p>
+        <p>
+          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
+        </p>
+        <p class="about-signature">
+          Com carinho,<br />
+          Bruna, Marta e Letícia.
+        </p>
+        <p class="about-highlight">Nós somos a NailNow!</p>
+      </section>
     </main>
 
     <footer class="site-footer">
@@ -185,6 +234,7 @@
         <div class="footer-links">
           <a href="cliente/">Área da cliente</a>
           <a href="profissional/">Área da profissional</a>
+          <a href="#quem-somos">Quem somos nós</a>
         </div>
         <div class="footer-contact">
           <a href="mailto:contato@nailnow.com">contato@nailnow.com</a>

--- a/styles.css
+++ b/styles.css
@@ -573,6 +573,45 @@ main {
   pointer-events: none;
 }
 
+.about {
+  max-width: var(--max-width);
+  margin: clamp(4rem, 8vw, 6.5rem) auto;
+  padding: clamp(2.75rem, 6vw, 4.5rem) clamp(2rem, 6vw, 4rem);
+  background: var(--surface);
+  border-radius: 32px;
+  box-shadow: 0 30px 60px rgba(79, 39, 49, 0.12);
+}
+
+.about h2 {
+  margin: 0 0 1.75rem;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.1rem, 4vw, 3rem);
+  color: var(--deep-rose);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.about p {
+  margin: 0;
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  color: var(--text-main);
+}
+
+.about p + p {
+  margin-top: 1.1rem;
+}
+
+.about-signature {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.about-highlight {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.3rem, 3vw, 1.8rem);
+  color: var(--gold);
+}
+
 .site-footer {
   background: rgba(78, 43, 52, 0.95);
   color: #fff;


### PR DESCRIPTION
## Summary
- add a dedicated "Quem somos" section with the full story text provided by the founders
- style the about section to match the site's visual language and highlight the signature

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc0c518df48333ba2ff64d2c7f9c59