### PR TITLE
Add agendamentos hub and refresh navigation

### DIFF
--- a/agendamentos.html
+++ b/agendamentos.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Central de agendamentos da NailNow com notificações em tempo real, reagendamentos flexíveis e histórico completo."
+    />
+    <title>Agendamentos | NailNow</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
+    <header class="site-header">
+      <div class="header-inner">
+        <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
+          NailNow
+        </a>
+        <nav class="primary-nav" aria-label="Principal">
+          <a href="index.html" class="nav-link">Home</a>
+          <a href="como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="servicos.html" class="nav-link">Serviços</a>
+          <a href="agendamentos.html" class="nav-link" aria-current="page">Agendamentos</a>
+        </nav>
+        <div class="header-actions">
+          <a href="cliente/index.html" class="header-cta">Sou Cliente</a>
+          <a href="profissional/index.html" class="header-cta">Sou Manicure</a>
+          <a
+            class="social-link social-link--instagram"
+            href="https://www.instagram.com/nailnowbr/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram da NailNow"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="page-hero">
+        <span class="eyebrow">Minha agenda</span>
+        <h1>Gerencie seus agendamentos com tranquilidade</h1>
+        <p>
+          Veja confirmações em tempo real, acompanhe deslocamentos e ajuste horários em segundos. Tudo centralizado para você
+          aproveitar cada atendimento sem preocupações.
+        </p>
+      </section>
+
+      <section class="flow">
+        <div class="section-heading">
+          <h2>Controle total do pedido ao pós-atendimento</h2>
+          <p>Planeje, confirme e avalie cada encontro com apoio da equipe NailNow do início ao fim.</p>
+        </div>
+        <ol class="flow-steps">
+          <li>
+            <span class="flow-step__number">1</span>
+            <h3>Confirme com um toque</h3>
+            <p>Receba notificações instantâneas assim que a manicure aceita o pedido e confirme diretamente pelo app.</p>
+          </li>
+          <li>
+            <span class="flow-step__number">2</span>
+            <h3>Gerencie alterações</h3>
+            <p>Precisa remarcar? Escolha novos horários disponíveis e confirme com suporte humano em minutos.</p>
+          </li>
+          <li>
+            <span class="flow-step__number">3</span>
+            <h3>Avalie e favorite</h3>
+            <p>Finalize avaliando o atendimento, dê gorjetas digitais e favorite profissionais para agendar novamente.</p>
+          </li>
+        </ol>
+      </section>
+
+      <section class="landing-overview" aria-label="Recursos da central de agendamentos">
+        <div class="section-heading">
+          <span class="eyebrow">Recursos exclusivos</span>
+          <h2>Seu histórico sempre organizado</h2>
+          <p>Centralize todos os compromissos e acompanhe o status de cada atendimento sem sair da página.</p>
+        </div>
+        <div class="landing-overview__grid">
+          <div class="landing-overview__card">
+            <span class="landing-overview__eyebrow">Alertas inteligentes</span>
+            <h3>Lembretes automáticos</h3>
+            <p>Receba avisos sobre horário de saída da manicure e notificações de chegada na sua localização.</p>
+            <span class="landing-overview__cta">Tudo em tempo real</span>
+          </div>
+          <div class="landing-overview__card">
+            <span class="landing-overview__eyebrow">Histórico completo</span>
+            <h3>Atendimentos anteriores</h3>
+            <p>Acesse datas, serviços realizados e avaliações para repetir combinações que deram certo.</p>
+            <span class="landing-overview__cta">Revise detalhes</span>
+          </div>
+          <div class="landing-overview__card">
+            <span class="landing-overview__eyebrow">Suporte humanizado</span>
+            <h3>Ajuda imediata</h3>
+            <p>Converse com especialistas para solucionar imprevistos, emitir reembolsos e confirmar reagendamentos.</p>
+            <span class="landing-overview__cta">Conte com a NailNow</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Pronta para organizar sua próxima sessão?</h2>
+          <p>
+            Entre na área do cliente e acompanhe todos os compromissos, pagamentos e avaliações com poucos cliques.
+          </p>
+        </div>
+        <a href="cliente/index.html" class="btn">Acessar minha agenda</a>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <div class="footer-column footer-column--brand">
+          <h2 class="footer-logo">NailNow</h2>
+          <p>Beleza na sua agenda com profissionais selecionadas, atendimento onde você estiver e suporte humanizado.</p>
+        </div>
+        <div class="footer-column footer-links" aria-label="Links úteis">
+          <h3>FAQ</h3>
+          <a href="faq.html">Perguntas frequentes</a>
+          <a href="como-funciona.html">Como funciona</a>
+          <a href="agendamentos.html" aria-current="page">Agendamentos</a>
+        </div>
+        <div class="footer-column footer-links" aria-label="Contato e suporte">
+          <h3>Contato & suporte</h3>
+          <a href="mailto:contato@nailnow.com">contato@nailnow.com</a>
+        </div>
+        <div class="footer-column footer-links" aria-label="Termos e políticas">
+          <h3>Termos & políticas</h3>
+          <a href="#">Termos de uso</a>
+          <a href="#">Política de privacidade</a>
+          <a href="#">Cookies e preferências</a>
+        </div>
+      </div>
+      <p class="footer-copy">© NailNow 2025. Todos os direitos reservados.</p>
+    </footer>
+
+    <nav class="bottom-nav" aria-label="Navegação inferior fixa">
+      <a href="index.html" class="bottom-nav__link" aria-label="Ir para o início">Home</a>
+      <a href="servicos.html" class="bottom-nav__link" aria-label="Buscar serviços de manicure">Buscar</a>
+      <a href="cliente/index.html" class="bottom-nav__link" aria-label="Ver agendamentos">Agendamentos</a>
+      <a href="cliente/" class="bottom-nav__link" aria-label="Ver perfil ou fazer login">Perfil</a>
+    </nav>
+  </body>
+</html>

--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -28,10 +28,14 @@
           NailNow
         </a>
         <nav class="primary-nav" aria-label="Principal">
-          <a href="../#clientes" class="nav-link">Sou cliente</a>
-          <a href="../profissional/" class="nav-link">Sou profissional</a>
+          <a href="../index.html" class="nav-link">Home</a>
+          <a href="../como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="../servicos.html" class="nav-link">Serviços</a>
+          <a href="../agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
         <div class="header-actions">
+          <a href="../cliente/index.html" class="header-cta">Sou Cliente</a>
+          <a href="../profissional/index.html" class="header-cta">Sou Manicure</a>
           <a
             class="social-link social-link--instagram"
             href="https://www.instagram.com/nailnowbr/"
@@ -45,7 +49,6 @@
               />
             </svg>
           </a>
-          <a href="../cliente/" class="header-cta">Entrar</a>
         </div>
       </div>
     </header>

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -28,10 +28,14 @@
           NailNow
         </a>
         <nav class="primary-nav" aria-label="Principal">
-          <a href="../#clientes" class="nav-link">Sou cliente</a>
-          <a href="../profissional/" class="nav-link">Sou profissional</a>
+          <a href="../index.html" class="nav-link">Home</a>
+          <a href="../como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="../servicos.html" class="nav-link">Serviços</a>
+          <a href="../agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
         <div class="header-actions">
+          <a href="../cliente/index.html" class="header-cta">Sou Cliente</a>
+          <a href="../profissional/index.html" class="header-cta">Sou Manicure</a>
           <a
             class="social-link social-link--instagram"
             href="https://www.instagram.com/nailnowbr/"
@@ -45,7 +49,6 @@
               />
             </svg>
           </a>
-          <a href="../cliente/cadastro.html" class="header-cta">Criar conta</a>
         </div>
       </div>
     </header>

--- a/como-funciona.html
+++ b/como-funciona.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Conheça a história da NailNow, a amizade e o propósito que deram origem à plataforma."
+      content="Entenda o passo a passo do agendamento na NailNow, formas de pagamento e suporte disponível."
     />
-    <title>Quem somos | NailNow</title>
+    <title>Como funciona | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
         <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
@@ -25,7 +25,7 @@
         </a>
         <nav class="primary-nav" aria-label="Principal">
           <a href="index.html" class="nav-link">Home</a>
-          <a href="como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="como-funciona.html" class="nav-link" aria-current="page">Como funciona</a>
           <a href="servicos.html" class="nav-link">Serviços</a>
           <a href="agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
@@ -50,53 +50,47 @@
     </header>
 
     <main>
-      <section id="quem-somos" class="about">
-        <h2>Quem somos?</h2>
+      <section class="page-hero">
+        <span class="eyebrow">Passo a passo</span>
+        <h1>Como funciona a NailNow</h1>
         <p>
-          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
-          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
+          Agende em minutos, acompanhe cada etapa pelo app e tenha suporte dedicado antes, durante e depois do atendimento.
         </p>
-        <p>
-          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de mudar
-          o mundo.
-        </p>
-        <p>
-          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que ser
-          aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
-        </p>
-        <p>
-          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar também a
-          vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder feminino se
-          une, “sai da frente”!
-        </p>
-        <p>
-          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
-        </p>
-        <p>
-          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
-          para depois.
-        </p>
-        <p>
-          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
-          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse os
-          dois mundos, de forma justa, moderna e eficiente.
-        </p>
-        <p>
-          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em nós,
-          tiramos de letra.
-        </p>
-        <p>
-          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres empoderadas,
-          lindas, livres e que não têm tempo a perder.
-        </p>
-        <p>
-          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
-        </p>
-        <p class="about-signature">
-          Com carinho,<br />
-          Bruna, Marta e Letícia.
-        </p>
-        <p class="about-highlight">Nós somos a NailNow!</p>
+      </section>
+
+      <section class="flow">
+        <div class="section-heading">
+          <h2>Veja como é simples usar a plataforma</h2>
+          <p>Escolha o serviço, defina o melhor horário e confirme com segurança.</p>
+        </div>
+        <ol class="flow-steps">
+          <li>
+            <span class="flow-step__number">1</span>
+            <h3>Escolha o serviço perfeito</h3>
+            <p>Selecione manicure, pedicure, spa dos pés e outras combinações criadas por especialistas.</p>
+          </li>
+          <li>
+            <span class="flow-step__number">2</span>
+            <h3>Defina horário e local</h3>
+            <p>Informe onde quer ser atendida e encontre horários flexíveis com profissionais próximas.</p>
+          </li>
+          <li>
+            <span class="flow-step__number">3</span>
+            <h3>Confirme e acompanhe</h3>
+            <p>Receba notificações, acompanhe o deslocamento e avalie sua experiência direto pelo app.</p>
+          </li>
+        </ol>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Suporte humanizado em cada etapa</h2>
+          <p>
+            Nossa equipe monitora os atendimentos em tempo real e está disponível para reagendar, solucionar dúvidas e garantir
+            que cada experiência supere suas expectativas.
+          </p>
+        </div>
+        <a href="cliente/index.html" class="btn">Começar agora</a>
       </section>
     </main>
 
@@ -109,7 +103,7 @@
         <div class="footer-column footer-links" aria-label="Links úteis">
           <h3>FAQ</h3>
           <a href="faq.html">Perguntas frequentes</a>
-          <a href="como-funciona.html">Como funciona</a>
+          <a href="como-funciona.html" aria-current="page">Como funciona</a>
           <a href="agendamentos.html">Agendamentos</a>
         </div>
         <div class="footer-column footer-links" aria-label="Contato e suporte">

--- a/conteudo.html
+++ b/conteudo.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Conheça a história da NailNow, a amizade e o propósito que deram origem à plataforma."
+      content="Conteúdo NailNow com dicas de beleza, tendências de esmaltes, tutoriais e bastidores da comunidade."
     />
-    <title>Quem somos | NailNow</title>
+    <title>Conteúdo | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
         <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
@@ -50,53 +50,42 @@
     </header>
 
     <main>
-      <section id="quem-somos" class="about">
-        <h2>Quem somos?</h2>
-        <p>
-          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
-          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
-        </p>
-        <p>
-          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de mudar
-          o mundo.
-        </p>
-        <p>
-          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que ser
-          aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
-        </p>
-        <p>
-          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar também a
-          vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder feminino se
-          une, “sai da frente”!
-        </p>
-        <p>
-          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
-        </p>
-        <p>
-          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
-          para depois.
-        </p>
-        <p>
-          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
-          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse os
-          dois mundos, de forma justa, moderna e eficiente.
-        </p>
-        <p>
-          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em nós,
-          tiramos de letra.
-        </p>
-        <p>
-          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres empoderadas,
-          lindas, livres e que não têm tempo a perder.
-        </p>
-        <p>
-          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
-        </p>
-        <p class="about-signature">
-          Com carinho,<br />
-          Bruna, Marta e Letícia.
-        </p>
-        <p class="about-highlight">Nós somos a NailNow!</p>
+      <section class="page-hero">
+        <span class="eyebrow">Conteúdo NailNow</span>
+        <h1>Dicas, tendências e tutoriais</h1>
+        <p>Atualizamos sempre com novidades do universo de beleza para você se inspirar entre um atendimento e outro.</p>
+      </section>
+
+      <section class="content">
+        <div class="section-heading">
+          <h2>Artigos e guias recentes</h2>
+          <p>Acesse materiais exclusivos produzidos com a curadoria das nossas manicures parceiras.</p>
+        </div>
+        <div class="content-grid">
+          <article class="content-card">
+            <h3>5 cores que vão dominar a próxima estação</h3>
+            <p>Descubra as paletas favoritas das nossas parceiras e como combinar com diferentes tons de pele.</p>
+            <a href="#" class="content-card__link">Ler artigo</a>
+          </article>
+          <article class="content-card">
+            <h3>Tutorial: spa das mãos em casa</h3>
+            <p>Passo a passo para potencializar o atendimento da manicure e manter suas mãos hidratadas por mais tempo.</p>
+            <a href="#" class="content-card__link">Ver tutorial</a>
+          </article>
+          <article class="content-card">
+            <h3>Por trás da NailNow</h3>
+            <p>Conheça nossa rede de suporte às profissionais parceiras e como garantimos uma experiência premium.</p>
+            <a href="quem-somos.html" class="content-card__link">Saiba mais</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Receba novidades em primeira mão</h2>
+          <p>Inscreva-se para receber alertas de novos artigos, lançamentos de serviços e benefícios exclusivos.</p>
+        </div>
+        <a href="index.html#newsletter" class="btn">Quero receber</a>
       </section>
     </main>
 

--- a/depoimentos.html
+++ b/depoimentos.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Conheça a história da NailNow, a amizade e o propósito que deram origem à plataforma."
+      content="Leia relatos reais de clientes da NailNow sobre agendamentos de manicure e experiências personalizadas."
     />
-    <title>Quem somos | NailNow</title>
+    <title>Depoimentos | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
         <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
@@ -50,53 +50,45 @@
     </header>
 
     <main>
-      <section id="quem-somos" class="about">
-        <h2>Quem somos?</h2>
-        <p>
-          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
-          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
-        </p>
-        <p>
-          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de mudar
-          o mundo.
-        </p>
-        <p>
-          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que ser
-          aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
-        </p>
-        <p>
-          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar também a
-          vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder feminino se
-          une, “sai da frente”!
-        </p>
-        <p>
-          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
-        </p>
-        <p>
-          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
-          para depois.
-        </p>
-        <p>
-          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
-          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse os
-          dois mundos, de forma justa, moderna e eficiente.
-        </p>
-        <p>
-          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em nós,
-          tiramos de letra.
-        </p>
-        <p>
-          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres empoderadas,
-          lindas, livres e que não têm tempo a perder.
-        </p>
-        <p>
-          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
-        </p>
-        <p class="about-signature">
-          Com carinho,<br />
-          Bruna, Marta e Letícia.
-        </p>
-        <p class="about-highlight">Nós somos a NailNow!</p>
+      <section class="page-hero">
+        <span class="eyebrow">Depoimentos</span>
+        <h1>Histórias reais de clientes NailNow</h1>
+        <p>Quem já agendou com a gente conta como é ter beleza profissional na hora certa.</p>
+      </section>
+
+      <section class="testimonials">
+        <div class="section-heading">
+          <h2>Experiências que inspiram confiança</h2>
+          <p>Selecionamos relatos completos para mostrar o impacto do atendimento personalizado.</p>
+        </div>
+        <div class="testimonials-grid">
+          <figure class="testimonial-card">
+            <blockquote>
+              "Nunca foi tão simples cuidar das minhas unhas. Agendei do trabalho e a manicure chegou pontualmente com todos os materiais higienizados."
+            </blockquote>
+            <figcaption>Renata • São Paulo</figcaption>
+          </figure>
+          <figure class="testimonial-card">
+            <blockquote>
+              "Adoro poder escolher por avaliações reais. As sugestões da NailNow acertam meu estilo toda vez!"
+            </blockquote>
+            <figcaption>Camila • Belo Horizonte</figcaption>
+          </figure>
+          <figure class="testimonial-card">
+            <blockquote>
+              "Usei para o dia do meu casamento e foi perfeito. Atendimento cuidadoso e retoques incluídos no pacote."
+            </blockquote>
+            <figcaption>Bianca • Campinas</figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Pronta para viver a experiência NailNow?</h2>
+          <p>Escolha sua manicure favorita, agende em poucos cliques e receba atendimento premium onde estiver.</p>
+        </div>
+        <a href="cliente/index.html" class="btn">Agendar atendimento</a>
       </section>
     </main>
 

--- a/faq.html
+++ b/faq.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Conheça a história da NailNow, a amizade e o propósito que deram origem à plataforma."
+      content="Dúvidas frequentes sobre o serviço NailNow: deslocamento, pagamento, cancelamento e seleção de profissionais."
     />
-    <title>Quem somos | NailNow</title>
+    <title>FAQ | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
         <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
@@ -50,53 +50,43 @@
     </header>
 
     <main>
-      <section id="quem-somos" class="about">
-        <h2>Quem somos?</h2>
-        <p>
-          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
-          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
-        </p>
-        <p>
-          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de mudar
-          o mundo.
-        </p>
-        <p>
-          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que ser
-          aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
-        </p>
-        <p>
-          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar também a
-          vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder feminino se
-          une, “sai da frente”!
-        </p>
-        <p>
-          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
-        </p>
-        <p>
-          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
-          para depois.
-        </p>
-        <p>
-          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
-          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse os
-          dois mundos, de forma justa, moderna e eficiente.
-        </p>
-        <p>
-          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em nós,
-          tiramos de letra.
-        </p>
-        <p>
-          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres empoderadas,
-          lindas, livres e que não têm tempo a perder.
-        </p>
-        <p>
-          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
-        </p>
-        <p class="about-signature">
-          Com carinho,<br />
-          Bruna, Marta e Letícia.
-        </p>
-        <p class="about-highlight">Nós somos a NailNow!</p>
+      <section class="page-hero">
+        <span class="eyebrow">FAQ</span>
+        <h1>Dúvidas frequentes</h1>
+        <p>Transparência para você agendar com segurança. Se preferir, fale com nosso time pelo chat.</p>
+      </section>
+
+      <section class="faq">
+        <div class="section-heading">
+          <h2>Principais tópicos</h2>
+          <p>Clique em cada pergunta para ver a resposta completa.</p>
+        </div>
+        <div class="faq-list" role="list">
+          <details class="faq-item" role="listitem" open>
+            <summary>Tem custo de deslocamento?</summary>
+            <p>O deslocamento está incluso nas regiões atendidas. Para locais fora da área de cobertura informamos o valor extra antes da confirmação.</p>
+          </details>
+          <details class="faq-item" role="listitem">
+            <summary>Como funciona o pagamento?</summary>
+            <p>O pagamento é feito direto pelo app com cartão, PIX ou carteira NailNow. Você só é cobrada após o atendimento confirmado.</p>
+          </details>
+          <details class="faq-item" role="listitem">
+            <summary>Posso cancelar sem custo?</summary>
+            <p>Cancelamentos até 2 horas antes do horário marcado são gratuitos. Após esse período, cobramos apenas uma taxa simbólica para a profissional.</p>
+          </details>
+          <details class="faq-item" role="listitem">
+            <summary>Como vocês selecionam as profissionais?</summary>
+            <p>Realizamos verificação de documentos, teste prático e análise contínua das avaliações das clientes antes de liberar cada parceira.</p>
+          </details>
+        </div>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Precisa de atendimento imediato?</h2>
+          <p>Converse com nosso time pelo chat do app ou envie um e-mail que retornamos rapidinho.</p>
+        </div>
+        <a href="mailto:contato@nailnow.com" class="btn">Falar com suporte</a>
       </section>
     </main>
 
@@ -108,7 +98,7 @@
         </div>
         <div class="footer-column footer-links" aria-label="Links úteis">
           <h3>FAQ</h3>
-          <a href="faq.html">Perguntas frequentes</a>
+          <a href="faq.html" aria-current="page">Perguntas frequentes</a>
           <a href="como-funciona.html">Como funciona</a>
           <a href="agendamentos.html">Agendamentos</a>
         </div>

--- a/index.html
+++ b/index.html
@@ -17,17 +17,21 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
-        <a href="./" class="brand-mark" aria-label="Início da NailNow">
+        <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
           NailNow
         </a>
         <nav class="primary-nav" aria-label="Principal">
-          <a href="#clientes" class="nav-link">Sou cliente</a>
-          <a href="profissional/" class="nav-link">Sou profissional</a>
+          <a href="index.html" class="nav-link" aria-current="page">Home</a>
+          <a href="como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="servicos.html" class="nav-link">Serviços</a>
+          <a href="agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
         <div class="header-actions">
+          <a href="cliente/index.html" class="header-cta">Sou Cliente</a>
+          <a href="profissional/index.html" class="header-cta">Sou Manicure</a>
           <a
             class="social-link social-link--instagram"
             href="https://www.instagram.com/nailnowbr/"
@@ -41,18 +45,17 @@
               />
             </svg>
           </a>
-          <a href="cliente/" class="header-cta">Entrar</a>
         </div>
       </div>
     </header>
 
     <main>
-      <section id="clientes" class="hero">
+      <section class="hero">
         <div class="hero-copy">
           <span class="hero-label">Para clientes</span>
-          <h1>Beleza on-demand com experiência premium</h1>
+          <h1>Beleza na sua agenda</h1>
           <p>
-            Encontre manicures avaliadas pela comunidade, acompanhe cada etapa do atendimento em tempo real e gerencie seus agendamentos como nas grandes plataformas.
+            Manicure de qualidade, onde você estiver. Agende em 3 cliques, acompanhe o deslocamento da profissional e receba atendimento premium na sua casa ou no trabalho.
           </p>
           <form class="booking-card" aria-label="Buscar manicures disponíveis" onsubmit="event.preventDefault();">
             <div class="booking-card__field">
@@ -103,25 +106,25 @@
                   </svg>
                 </div>
               </div>
-              <div class="booking-card__field">
-                <label class="booking-card__label" for="booking-time">Horário</label>
-                <div class="booking-card__control booking-card__control--compact">
-                  <input type="time" id="booking-time" name="time" class="booking-card__input" />
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
+            <div class="booking-card__field">
+              <label class="booking-card__label" for="booking-time">Horário</label>
+              <div class="booking-card__control booking-card__control--compact">
+                <input type="time" id="booking-time" name="time" class="booking-card__input" />
+                <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
                     <path
                       d="M12 2.5a9.5 9.5 0 1 0 9.5 9.5A9.5 9.5 0 0 0 12 2.5Zm-.75 4a.75.75 0 0 1 1.5 0v4.19l3.22 1.86a.75.75 0 0 1-.75 1.3l-3.6-2.08a.75.75 0 0 1-.37-.64Z"
                     />
-                  </svg>
-                </div>
+                </svg>
               </div>
             </div>
-            <button type="button" class="booking-card__submit">Ver manicures</button>
-            <p class="booking-card__note">Descubra manicures avaliadas perto de você com suporte dedicado 7 dias por semana.</p>
-          </form>
-        </div>
-        <div class="hero-media">
-          <div class="hero-image-wrapper">
-            <img
+          </div>
+          <button type="button" class="booking-card__submit">Agende agora</button>
+          <p class="booking-card__note">Suporte dedicado e avaliações reais para você escolher a manicure ideal com tranquilidade.</p>
+        </form>
+      </div>
+      <div class="hero-media">
+        <div class="hero-image-wrapper">
+          <img
               src="assets/nail1.png"
               alt="Cliente sorrindo enquanto faz as unhas com uma manicure"
             />
@@ -129,102 +132,67 @@
         </div>
       </section>
 
-      <section class="trust-bar" aria-label="Parceiros e reconhecimento">
-        <div class="trust-bar__inner">
-          <p class="trust-bar__headline">A experiência NailNow inspira confiança nos principais players de beleza</p>
-          <div class="trust-bar__logos" role="list">
-            <span role="listitem">BeautyLab</span>
-            <span role="listitem">Studio Prisma</span>
-            <span role="listitem">Aurora Lounge</span>
-            <span role="listitem">Urban Care</span>
-          </div>
-        </div>
-      </section>
-
-      <section id="como-funciona" class="flow">
+      <section class="landing-overview" aria-label="Principais conteúdos">
         <div class="section-heading">
-          <span class="eyebrow">Passo a passo</span>
-          <h2>Como funciona a NailNow</h2>
+          <span class="eyebrow">Explore a NailNow</span>
+          <h2>Encontre o conteúdo certo em poucos cliques</h2>
           <p>
-            Do agendamento ao pagamento, cuidamos de tudo para você relaxar e aproveitar o momento.
+            Reunimos tudo em páginas dedicadas para você acessar rapidamente informações sobre serviços, profissionais,
+            depoimentos e suporte.
           </p>
         </div>
-        <ol class="flow-steps">
-          <li>
-            <span class="flow-step__number">1</span>
-            <h3>Escolha o serviço perfeito</h3>
-            <p>Selecione manicure, pedicure, spa dos pés e outras combinações criadas por especialistas.</p>
-          </li>
-          <li>
-            <span class="flow-step__number">2</span>
-            <h3>Defina horário e local</h3>
-            <p>Informe onde quer ser atendida e encontre horários flexíveis com profissionais próximas.</p>
-          </li>
-          <li>
-            <span class="flow-step__number">3</span>
-            <h3>Confirme e acompanhe</h3>
-            <p>Receba notificações, acompanhe o deslocamento e avalie sua experiência direto pelo app.</p>
-          </li>
-        </ol>
-      </section>
-
-      <section class="feature-grid">
-        <div class="section-heading">
-          <span class="eyebrow">Por que escolher a NailNow</span>
-          <h2>Detalhes dignos de grandes marcas</h2>
-          <p>
-            Segurança, tecnologia e atendimento humano combinados para entregar um padrão premium em cada visita.
-          </p>
-        </div>
-        <div class="feature-grid__items">
-          <article class="feature-card">
-            <div class="feature-card__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" role="presentation">
-                <path
-                  d="M12 2 2 7l10 5 10-5-10-5Zm0 9-7.53-3.77L12 3.44l7.53 3.79L12 11ZM4 12.64l8 4 8-4V17l-8 4-8-4v-4.36Z"
-                />
-              </svg>
-            </div>
-            <h3>Infraestrutura confiável</h3>
-            <p>Backups automáticos, pagamentos protegidos e monitoramento em tempo real asseguram suas reservas.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-card__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" role="presentation">
-                <path
-                  d="M12 2a7 7 0 0 0-7 7v3.53a3 3 0 0 1-.88 2.12l-.94.94A1 1 0 0 0 4 17h16a1 1 0 0 0 .71-1.71l-.94-.94A3 3 0 0 1 18 12.53V9a7 7 0 0 0-6-6.93V2Zm0 20a3 3 0 0 0 3-3H9a3 3 0 0 0 3 3Z"
-                />
-              </svg>
-            </div>
-            <h3>Suporte proativo</h3>
-            <p>Equipe dedicada acompanha cada atendimento com SLA de respostas rápidas e comunicação omnichannel.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-card__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" role="presentation">
-                <path
-                  d="M4 4h16v2H4V4Zm2 4h12v2H6V8Zm-2 4h16v2H4v-2Zm2 4h12v2H6v-2Z"
-                />
-              </svg>
-            </div>
-            <h3>Dashboards inteligentes</h3>
-            <p>Relatórios e insights alimentados por dados para que você acompanhe reputação, recorrência e receita.</p>
-          </article>
+        <div class="landing-overview__grid">
+          <a class="landing-overview__card" href="como-funciona.html">
+            <span class="landing-overview__eyebrow">Passo a passo</span>
+            <h3>Como funciona a NailNow</h3>
+            <p>Veja cada etapa do agendamento, pagamentos e suporte direto na página dedicada.</p>
+            <span class="landing-overview__cta">Saiba como agendar</span>
+          </a>
+          <a class="landing-overview__card" href="servicos.html">
+            <span class="landing-overview__eyebrow">Serviços</span>
+            <h3>Catálogo completo de cuidados</h3>
+            <p>Conheça os pacotes de manicure, pedicure, spa e experiências especiais por perfil.</p>
+            <span class="landing-overview__cta">Ver opções</span>
+          </a>
+          <a class="landing-overview__card" href="manicures.html">
+            <span class="landing-overview__eyebrow">Profissionais</span>
+            <h3>Manicures parceiras verificadas</h3>
+            <p>Descubra quem está na rede NailNow e como selecionamos cada especialista.</p>
+            <span class="landing-overview__cta">Conhecer rede</span>
+          </a>
+          <a class="landing-overview__card" href="depoimentos.html">
+            <span class="landing-overview__eyebrow">Depoimentos</span>
+            <h3>Histórias reais das clientes</h3>
+            <p>Leia avaliações completas e experiências marcantes com atendimentos NailNow.</p>
+            <span class="landing-overview__cta">Ler relatos</span>
+          </a>
+          <a class="landing-overview__card" href="faq.html">
+            <span class="landing-overview__eyebrow">FAQ</span>
+            <h3>Dúvidas frequentes respondidas</h3>
+            <p>Encontre respostas sobre deslocamento, pagamento, cancelamentos e seleção de profissionais.</p>
+            <span class="landing-overview__cta">Consultar FAQ</span>
+          </a>
+          <a class="landing-overview__card" href="agendamentos.html">
+            <span class="landing-overview__eyebrow">Minha agenda</span>
+            <h3>Central de agendamentos</h3>
+            <p>Organize compromissos, acompanhe confirmações e receba notificações em tempo real.</p>
+            <span class="landing-overview__cta">Gerenciar horários</span>
+          </a>
         </div>
       </section>
 
       <section class="cta-profissional" id="profissionais">
         <div class="cta-content">
           <span class="eyebrow">Para manicures</span>
-          <h2>Atenda novas clientes com a NailNow</h2>
+          <h2>Seja uma manicure parceira NailNow</h2>
           <p>
-            Cadastre-se gratuitamente, defina sua agenda, receba pagamentos com rapidez e tenha suporte em cada atendimento.
+            Cadastre-se gratuitamente, receba pedidos recorrentes e tenha suporte financeiro, logístico e de marketing a cada atendimento.
           </p>
         </div>
-        <a href="profissional/" class="btn btn--light">Quero fazer parte</a>
+        <a href="profissional/" class="btn btn--light">Cadastrar-se</a>
       </section>
 
-      <section class="newsletter">
+      <section class="newsletter" id="newsletter">
         <h2>Receba novidades da NailNow</h2>
         <p>
           Fique por dentro do lançamento do aplicativo, benefícios exclusivos e dicas de autocuidado.
@@ -238,12 +206,6 @@
           />
           <button type="submit">Quero receber</button>
         </form>
-        <img
-          src="gold-watermark.png"
-          class="watermark"
-          alt=""
-          aria-hidden="true"
-        />
       </section>
 
     </main>
@@ -252,13 +214,33 @@
       <div class="footer-inner">
         <div class="footer-column footer-column--brand">
           <h2 class="footer-logo">NailNow</h2>
-          <p>Beleza na sua agenda, com profissionais selecionadas e atendimento onde você estiver.</p>
+          <p>Beleza na sua agenda com profissionais selecionadas, atendimento onde você estiver e suporte humanizado.</p>
         </div>
-        <nav class="footer-column footer-links" aria-label="Links do rodapé">
-          <a href="quem-somos.html">Quem somos nós</a>
-        </nav>
+        <div class="footer-column footer-links" aria-label="Links úteis">
+          <h3>FAQ</h3>
+          <a href="faq.html">Perguntas frequentes</a>
+          <a href="como-funciona.html">Como funciona</a>
+          <a href="agendamentos.html">Agendamentos</a>
+        </div>
+        <div class="footer-column footer-links" aria-label="Contato e suporte">
+          <h3>Contato & suporte</h3>
+          <a href="mailto:contato@nailnow.com">contato@nailnow.com</a>
+        </div>
+        <div class="footer-column footer-links" aria-label="Termos e políticas">
+          <h3>Termos & políticas</h3>
+          <a href="#">Termos de uso</a>
+          <a href="#">Política de privacidade</a>
+          <a href="#">Cookies e preferências</a>
+        </div>
       </div>
       <p class="footer-copy">© NailNow 2025. Todos os direitos reservados.</p>
     </footer>
+
+    <nav class="bottom-nav" aria-label="Navegação inferior fixa">
+      <a href="index.html" class="bottom-nav__link" aria-label="Ir para o início">Home</a>
+      <a href="servicos.html" class="bottom-nav__link" aria-label="Buscar serviços de manicure">Buscar</a>
+      <a href="cliente/index.html" class="bottom-nav__link" aria-label="Ver agendamentos">Agendamentos</a>
+      <a href="cliente/" class="bottom-nav__link" aria-label="Ver perfil ou fazer login">Perfil</a>
+    </nav>
   </body>
 </html>

--- a/manicures.html
+++ b/manicures.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Conheça a história da NailNow, a amizade e o propósito que deram origem à plataforma."
+      content="Conheça a rede de manicures parceiras da NailNow, profissionais verificadas e avaliadas pelas clientes."
     />
-    <title>Quem somos | NailNow</title>
+    <title>Manicures parceiras | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
         <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
@@ -50,53 +50,54 @@
     </header>
 
     <main>
-      <section id="quem-somos" class="about">
-        <h2>Quem somos?</h2>
-        <p>
-          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
-          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
-        </p>
-        <p>
-          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de mudar
-          o mundo.
-        </p>
-        <p>
-          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que ser
-          aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
-        </p>
-        <p>
-          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar também a
-          vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder feminino se
-          une, “sai da frente”!
-        </p>
-        <p>
-          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
-        </p>
-        <p>
-          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
-          para depois.
-        </p>
-        <p>
-          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
-          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse os
-          dois mundos, de forma justa, moderna e eficiente.
-        </p>
-        <p>
-          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em nós,
-          tiramos de letra.
-        </p>
-        <p>
-          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres empoderadas,
-          lindas, livres e que não têm tempo a perder.
-        </p>
-        <p>
-          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
-        </p>
-        <p class="about-signature">
-          Com carinho,<br />
-          Bruna, Marta e Letícia.
-        </p>
-        <p class="about-highlight">Nós somos a NailNow!</p>
+      <section class="page-hero">
+        <span class="eyebrow">Profissionais</span>
+        <h1>Manicures parceiras NailNow</h1>
+        <p>Parceiras homologadas, especialistas em tendências e com avaliações transparentes das clientes.</p>
+      </section>
+
+      <section class="partners">
+        <div class="section-heading">
+          <h2>Conheça algumas das especialistas</h2>
+          <p>Selecionamos manicures com portfólio validado e atendimento impecável em diferentes regiões.</p>
+        </div>
+        <div class="partners-grid">
+          <article class="partner-card">
+            <div class="partner-card__avatar" aria-hidden="true"></div>
+            <div class="partner-card__body">
+              <h3>Ana Luiza</h3>
+              <p>Especialista em nail art minimalista e spa das mãos. Nota média 4,9 com mais de 120 atendimentos.</p>
+              <span class="partner-card__tag">Zona Sul · SP</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <div class="partner-card__avatar partner-card__avatar--sunset" aria-hidden="true"></div>
+            <div class="partner-card__body">
+              <h3>Mariana Costa</h3>
+              <p>Referência em alongamentos em gel e fibra. Agenda flexível inclusive aos domingos.</p>
+              <span class="partner-card__tag">Centro · BH</span>
+            </div>
+          </article>
+          <article class="partner-card">
+            <div class="partner-card__avatar partner-card__avatar--violet" aria-hidden="true"></div>
+            <div class="partner-card__body">
+              <h3>Juliana Prado</h3>
+              <p>Manicure premium para eventos, com consultoria de cor e retoques a domicílio.</p>
+              <span class="partner-card__tag">Savassi · BH</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Quer fazer parte da nossa rede?</h2>
+          <p>
+            Cadastre-se como manicure parceira e tenha agenda cheia, suporte financeiro e divulgação contínua dos seus
+            serviços.
+          </p>
+        </div>
+        <a href="profissional/" class="btn">Seja parceira</a>
       </section>
     </main>
 

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -28,10 +28,14 @@
           NailNow
         </a>
         <nav class="primary-nav" aria-label="Principal">
-          <a href="../#clientes" class="nav-link">Sou cliente</a>
-          <a href="../profissional/" class="nav-link">Sou profissional</a>
+          <a href="../index.html" class="nav-link">Home</a>
+          <a href="../como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="../servicos.html" class="nav-link">Serviços</a>
+          <a href="../agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
         <div class="header-actions">
+          <a href="../cliente/index.html" class="header-cta">Sou Cliente</a>
+          <a href="../profissional/index.html" class="header-cta">Sou Manicure</a>
           <a
             class="social-link social-link--instagram"
             href="https://www.instagram.com/nailnowbr/"
@@ -45,7 +49,6 @@
               />
             </svg>
           </a>
-          <a href="../profissional/" class="header-cta">Entrar</a>
         </div>
       </div>
     </header>

--- a/profissional/index.html
+++ b/profissional/index.html
@@ -28,10 +28,14 @@
           NailNow
         </a>
         <nav class="primary-nav" aria-label="Principal">
-          <a href="../#clientes" class="nav-link">Sou cliente</a>
-          <a href="../profissional/" class="nav-link" aria-current="page">Sou profissional</a>
+          <a href="../index.html" class="nav-link">Home</a>
+          <a href="../como-funciona.html" class="nav-link">Como funciona</a>
+          <a href="../servicos.html" class="nav-link">Serviços</a>
+          <a href="../agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
         <div class="header-actions">
+          <a href="../cliente/index.html" class="header-cta">Sou Cliente</a>
+          <a href="../profissional/index.html" class="header-cta">Sou Manicure</a>
           <a
             class="social-link social-link--instagram"
             href="https://www.instagram.com/nailnowbr/"
@@ -45,7 +49,6 @@
               />
             </svg>
           </a>
-          <a href="../profissional/cadastro.html" class="header-cta">Cadastre-se</a>
         </div>
       </div>
     </header>

--- a/servicos.html
+++ b/servicos.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Conheça a história da NailNow, a amizade e o propósito que deram origem à plataforma."
+      content="Catálogo de serviços NailNow com pacotes de manicure, pedicure, spa dos pés e experiências premium."
     />
-    <title>Quem somos | NailNow</title>
+    <title>Serviços | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="promo-banner">Agende suas unhas com profissionais verificadas em minutos.</div>
+    <div class="promo-banner">Manicure sob medida: agende com profissionais verificadas onde você estiver.</div>
     <header class="site-header">
       <div class="header-inner">
         <a href="index.html" class="brand-mark" aria-label="Início da NailNow">
@@ -26,7 +26,7 @@
         <nav class="primary-nav" aria-label="Principal">
           <a href="index.html" class="nav-link">Home</a>
           <a href="como-funciona.html" class="nav-link">Como funciona</a>
-          <a href="servicos.html" class="nav-link">Serviços</a>
+          <a href="servicos.html" class="nav-link" aria-current="page">Serviços</a>
           <a href="agendamentos.html" class="nav-link">Agendamentos</a>
         </nav>
         <div class="header-actions">
@@ -50,53 +50,57 @@
     </header>
 
     <main>
-      <section id="quem-somos" class="about">
-        <h2>Quem somos?</h2>
-        <p>
-          Uma amizade de mais de 30 anos. Duas irmãs e a melhor amiga. Um momento de profundas mudanças na vida das três. Uma
-          conversa despretensiosa numa mesa de bar. E uma inquietação batendo no coração de cada uma.
-        </p>
-        <p>
-          Assim nasceu a NailNow: do coração de três mulheres inconformadas, com o sonho de mudar a vida e aquela utopia de mudar
-          o mundo.
-        </p>
-        <p>
-          Para nós, é muito verdadeira a velha máxima de que a mulher pode fazer tudo, inclusive mudar o mundo. Só que tem que ser
-          aos pouquinhos, ao nosso redor, no nosso pedacinho. E de pedacinho em pedacinho, se faz uma revolução!
-        </p>
-        <p>
-          Na vontade de transformar as nossas vidas, daquele inconformismo ali presente, nasceu o propósito de transformar também a
-          vida de muitas outras mulheres. Nós realmente acreditamos nesse poder que o feminino tem. E quando o poder feminino se
-          une, “sai da frente”!
-        </p>
-        <p>
-          E como diz a letra do Gonzaguinha que nós amamos na voz da Maria Rita: “da unidade vai nascer a novidade”. E nasceu!
-        </p>
-        <p>
-          A NailNow surgiu para conectar mulheres extraordinárias. Fortes, poderosas, revolucionárias e que não deixam o cuidado
-          para depois.
-        </p>
-        <p>
-          Percebemos que muitas mulheres ainda enfrentavam dificuldade em encontrar manicures disponíveis, e que profissionais
-          incríveis precisavam de mais visibilidade e oportunidades. Foi assim que surgiu a ideia: criar uma plataforma que unisse os
-          dois mundos, de forma justa, moderna e eficiente.
-        </p>
-        <p>
-          Transformar o cuidado com a beleza em algo prático, acessível e sofisticado é um desafio, mas com o poder feminino em nós,
-          tiramos de letra.
-        </p>
-        <p>
-          E a nossa missão é justamente essa: inovar nas conexões entre profissionais da beleza excepcionais e mulheres empoderadas,
-          lindas, livres e que não têm tempo a perder.
-        </p>
-        <p>
-          E é assim que nós três queremos mudar o mundo. O nosso mundo, e de todas as mulheres!
-        </p>
-        <p class="about-signature">
-          Com carinho,<br />
-          Bruna, Marta e Letícia.
-        </p>
-        <p class="about-highlight">Nós somos a NailNow!</p>
+      <section class="page-hero">
+        <span class="eyebrow">Serviços</span>
+        <h1>Cuidados completos para mãos e pés</h1>
+        <p>Escolha pacotes personalizados com profissionais verificadas e materiais premium.</p>
+      </section>
+
+      <section class="services">
+        <div class="section-heading">
+          <h2>Pacotes criados para diferentes momentos</h2>
+          <p>Encontre combinações perfeitas para o dia a dia, ocasiões especiais ou um momento de autocuidado.</p>
+        </div>
+        <div class="services-grid">
+          <article class="service-card">
+            <h3>Beleza express</h3>
+            <p>Manicure clássica com acabamento impecável em até 40 minutos. Ideal para manter a rotina em dia.</p>
+            <ul>
+              <li>Esmaltação tradicional</li>
+              <li>Acabamento com óleos nutritivos</li>
+              <li>Escolha entre mais de 30 cores</li>
+            </ul>
+          </article>
+          <article class="service-card">
+            <h3>Alongamento &amp; spa</h3>
+            <p>Procedimentos com gel, fibra e banhos relaxantes para um resultado de longa duração.</p>
+            <ul>
+              <li>Alongamento em gel ou fibra</li>
+              <li>Spa dos pés com esfoliação</li>
+              <li>Garantia NailNow de ajustes em 72h</li>
+            </ul>
+          </article>
+          <article class="service-card">
+            <h3>Eventos &amp; noivas</h3>
+            <p>Pacotes especiais com prova de cor, retoques antes do evento e atendimento exclusivo.</p>
+            <ul>
+              <li>Consultoria de estilo personalizada</li>
+              <li>Equipe adicional sob demanda</li>
+              <li>Atendimento em domicílio ou no local do evento</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="page-highlight">
+        <div class="page-highlight__content">
+          <h2>Personalize ainda mais sua experiência</h2>
+          <p>
+            Combine serviços, adicione nail art exclusiva e contrate pacotes recorrentes com valores especiais para manter suas
+            mãos impecáveis o mês todo.
+          </p>
+        </div>
+        <a href="cliente/index.html" class="btn">Agendar agora</a>
       </section>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,7 @@ body {
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  padding-bottom: 72px;
 }
 
 a {
@@ -71,7 +72,10 @@ button {
 }
 
 main {
-  padding: 0 clamp(1.5rem, 6vw, 3.75rem) clamp(4rem, 8vw, 6rem);
+  padding: 0 clamp(1.5rem, 6vw, 3.75rem) clamp(6rem, 10vw, 7.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4rem, 10vw, 6.5rem);
 }
 
 .promo-banner {
@@ -176,21 +180,23 @@ main {
   justify-content: center;
   padding: 0.55rem 1.4rem;
   border-radius: 999px;
-  border: 1px solid rgba(18, 18, 18, 0.08);
+  border: 1px solid var(--pink-primary);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-size: 0.78rem;
-  color: var(--text-main);
-  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
+  color: var(--surface);
+  background: var(--pink-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .header-cta:hover,
 .header-cta:focus-visible {
-  background: var(--pink-primary);
-  border-color: transparent;
+  background: var(--pink-accent);
+  border-color: var(--pink-accent);
   color: var(--surface);
   transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(244, 92, 162, 0.25);
 }
 
 .nav-link {
@@ -214,6 +220,15 @@ main {
   transition:
     width 0.3s ease,
     left 0.3s ease;
+}
+
+.nav-link[aria-current="page"] {
+  color: var(--pink-primary);
+}
+
+.nav-link[aria-current="page"]::after {
+  width: 100%;
+  left: 0;
 }
 
 .nav-link:hover,
@@ -320,6 +335,26 @@ main {
   margin: 0 0 2.4rem;
 }
 
+.page-hero {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+  display: grid;
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.page-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  color: var(--pink-primary);
+}
+
+.page-hero p {
+  margin: 0;
+  max-width: 60ch;
+}
+
 .trust-bar {
   max-width: var(--max-width);
   margin: clamp(1rem, 6vw, 2.5rem) auto clamp(3rem, 9vw, 5rem);
@@ -364,6 +399,64 @@ main {
   border-radius: 999px;
   border: 1px solid rgba(244, 92, 162, 0.24);
   background: var(--surface);
+}
+
+.landing-overview {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 3.5rem);
+}
+
+.landing-overview__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.landing-overview__card {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border-radius: 24px;
+  background: var(--surface-alt);
+  border: 1px solid rgba(244, 92, 162, 0.18);
+  box-shadow: 0 18px 36px rgba(18, 18, 18, 0.06);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.landing-overview__card:hover,
+.landing-overview__card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 48px rgba(244, 92, 162, 0.15);
+}
+
+.landing-overview__card h3 {
+  margin: 0;
+  color: var(--pink-primary);
+  font-size: clamp(1.3rem, 3vw, 1.75rem);
+}
+
+.landing-overview__card p {
+  margin: 0;
+}
+
+.landing-overview__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--pink-primary);
+  font-weight: 600;
+}
+
+.landing-overview__cta {
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: var(--pink-primary);
 }
 
 .booking-card {
@@ -693,52 +786,38 @@ main {
   margin: 0;
 }
 
-.feature-grid {
+.services {
   max-width: var(--max-width);
-  margin: clamp(3rem, 9vw, 6rem) auto;
-  padding: 0 clamp(1.5rem, 6vw, 3rem);
-}
-
-.feature-grid__items {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-.feature-card {
-  background: var(--surface);
-  border-radius: var(--radius-medium);
-  border: 1px solid rgba(244, 92, 162, 0.18);
-  padding: clamp(1.75rem, 4vw, 2.5rem);
+  margin: 0 auto;
+  background: linear-gradient(180deg, var(--surface) 0%, rgba(255, 244, 250, 0.9) 100%);
+  border-radius: clamp(1.5rem, 5vw, var(--radius-large));
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 6vw, 3rem);
   box-shadow: var(--shadow-sm);
+}
+
+.services-grid {
   display: grid;
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.75rem, 4vw, 2.5rem);
 }
 
-.feature-card__icon {
-  width: 56px;
-  height: 56px;
-  border-radius: 16px;
-  background: var(--surface-contrast);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(244, 92, 162, 0.24);
+.service-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.75rem;
+  border: 1px solid rgba(244, 92, 162, 0.18);
+  box-shadow: 0 18px 36px rgba(18, 18, 18, 0.06);
 }
 
-.feature-card__icon svg {
-  width: 28px;
-  height: 28px;
-  fill: var(--pink-primary);
+.service-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
 }
 
-.feature-card h3 {
-  margin: 0;
-  font-size: clamp(1.3rem, 3vw, 1.75rem);
-}
-
-.feature-card p {
-  margin: 0;
+.service-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--text-muted);
 }
 
 .eyebrow {
@@ -798,6 +877,210 @@ main {
 .cta-content p {
   margin: 0;
   color: var(--text-muted);
+}
+
+.page-highlight {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(2.25rem, 6vw, 3.25rem) clamp(1.5rem, 6vw, 3.5rem);
+  background: var(--surface-contrast);
+  border-radius: var(--radius-medium);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgba(244, 92, 162, 0.18);
+  box-shadow: var(--shadow-sm);
+  flex-wrap: wrap;
+}
+
+.page-highlight__content {
+  max-width: 520px;
+}
+
+.page-highlight__content h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 3.5vw, 2.4rem);
+  color: var(--pink-primary);
+}
+
+.page-highlight__content p {
+  margin: 0;
+}
+
+.partners {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 6vw, 3rem);
+}
+
+.partners-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.partner-card {
+  background: var(--surface);
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(18, 18, 18, 0.05);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.partner-card__avatar {
+  width: 100%;
+  height: 200px;
+  background: linear-gradient(135deg, #ffd6ec, #f45ca2);
+}
+
+.partner-card__avatar--sunset {
+  background: linear-gradient(135deg, #ffe6c7, #ff8a65);
+}
+
+.partner-card__avatar--violet {
+  background: linear-gradient(135deg, #e5d3ff, #8e6bff);
+}
+
+.partner-card__body {
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.partner-card__tag {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pink-primary);
+  background: var(--pink-secondary);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  align-self: flex-start;
+}
+
+.testimonials {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 6vw, 3rem);
+  background: var(--surface-contrast);
+  border-radius: clamp(1.5rem, 5vw, var(--radius-large));
+  box-shadow: var(--shadow-sm);
+}
+
+.testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.testimonial-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.75rem;
+  border: 1px solid rgba(18, 18, 18, 0.06);
+  box-shadow: 0 20px 40px rgba(18, 18, 18, 0.06);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.testimonial-card blockquote {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--text-main);
+}
+
+.testimonial-card figcaption {
+  font-weight: 600;
+  color: var(--pink-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+}
+
+.faq {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.faq-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.faq-item {
+  background: var(--surface);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(18, 18, 18, 0.06);
+  box-shadow: var(--shadow-sm);
+}
+
+.faq-item summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item[open] summary {
+  color: var(--pink-primary);
+}
+
+.faq-item p {
+  margin-top: 0.75rem;
+}
+
+.content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 clamp(1.5rem, 6vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.content-card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: 1.75rem;
+  border: 1px solid rgba(244, 92, 162, 0.15);
+  box-shadow: 0 20px 40px rgba(18, 18, 18, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.content-card__link {
+  color: var(--pink-primary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
 }
 
 .newsletter {
@@ -887,16 +1170,6 @@ main {
   box-shadow: 0 18px 28px rgba(244, 92, 162, 0.25);
 }
 
-.newsletter .watermark {
-  position: absolute;
-  inset: 45% auto auto 50%;
-  transform: translate(-50%, -40%);
-  width: clamp(260px, 58%, 420px);
-  opacity: 0.12;
-  z-index: 0;
-  pointer-events: none;
-}
-
 .about {
   max-width: var(--max-width);
   margin: clamp(4rem, 8vw, 6.5rem) auto;
@@ -939,20 +1212,18 @@ main {
 }
 
 .site-footer {
-  background: var(--surface);
-  color: var(--text-main);
-  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 6vw, 3.75rem);
-  border-top: 1px solid rgba(18, 18, 18, 0.08);
+  background: #101010;
+  color: rgba(255, 255, 255, 0.85);
+  padding: clamp(3rem, 6vw, 4.5rem) clamp(1.5rem, 6vw, 3.75rem);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .footer-inner {
   max-width: var(--max-width);
-  margin: 0 auto clamp(2rem, 6vw, 3rem);
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: clamp(1.5rem, 6vw, 3rem);
-  flex-wrap: wrap;
+  margin: 0 auto clamp(2.5rem, 6vw, 3.5rem);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: clamp(1.75rem, 6vw, 3rem);
 }
 
 .footer-column {
@@ -961,8 +1232,16 @@ main {
   gap: 0.75rem;
 }
 
+.footer-column h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--pink-secondary);
+}
+
 .footer-column--brand {
-  max-width: clamp(260px, 40vw, 420px);
+  max-width: clamp(260px, 40vw, 380px);
 }
 
 .footer-logo {
@@ -974,22 +1253,32 @@ main {
   color: var(--pink-primary);
 }
 
-.footer-links {
-  align-items: flex-end;
-  text-align: right;
-}
-
 .footer-links a {
-  color: var(--text-muted);
+  color: rgba(255, 255, 255, 0.7);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  font-size: 0.78rem;
   transition: color 0.3s ease;
 }
 
 .footer-links a:hover,
-.footer-links a:focus {
+.footer-links a:focus-visible {
   color: var(--pink-primary);
+}
+
+.footer-cta {
+  display: inline-flex;
+  margin-top: 1.25rem;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--pink-primary);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  align-self: flex-start;
 }
 
 .footer-copy {
@@ -999,7 +1288,35 @@ main {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   font-size: 0.75rem;
-  color: var(--text-muted);
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(255, 255, 255, 0.95);
+  border-top: 1px solid rgba(18, 18, 18, 0.08);
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  backdrop-filter: blur(16px);
+  z-index: 20;
+}
+
+.bottom-nav__link {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-main);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.bottom-nav__link:hover,
+.bottom-nav__link:focus-visible {
+  color: var(--pink-primary);
 }
 
 @media (max-width: 960px) {
@@ -1110,5 +1427,11 @@ main {
   .header-actions {
     width: 100%;
     justify-content: center;
+  }
+}
+
+@media (min-width: 960px) {
+  .bottom-nav {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- replace the Conteúdo item with Agendamentos across headers, set the CTA buttons ahead of the Instagram link, and restyle them in pink
- add a dedicated agendamentos.html page covering scheduling steps, resources, and a CTA for the cliente area
- streamline the home page highlights and footer links by featuring the new agendamentos card and removing the extra login, telefone e Instagram items

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1cec16f0c83339aed249b25e28622