### PR TITLE
Remove landing overview content cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,55 +134,6 @@
         </div>
       </section>
 
-      <section class="landing-overview" aria-label="Principais conteúdos">
-        <div class="section-heading">
-          <span class="eyebrow">Explore a NailNow</span>
-          <h2>Encontre o conteúdo certo em poucos cliques</h2>
-          <p>
-            Reunimos tudo em páginas dedicadas para você acessar rapidamente informações sobre serviços, profissionais,
-            depoimentos e suporte.
-          </p>
-        </div>
-        <div class="landing-overview__grid">
-          <a class="landing-overview__card" href="como-funciona.html">
-            <span class="landing-overview__eyebrow">Passo a passo</span>
-            <h3>Como funciona a NailNow</h3>
-            <p>Veja cada etapa do agendamento, pagamentos e suporte direto na página dedicada.</p>
-            <span class="landing-overview__cta">Saiba como agendar</span>
-          </a>
-          <a class="landing-overview__card" href="servicos.html">
-            <span class="landing-overview__eyebrow">Serviços</span>
-            <h3>Catálogo completo de cuidados</h3>
-            <p>Conheça os pacotes de manicure, pedicure, spa e experiências especiais por perfil.</p>
-            <span class="landing-overview__cta">Ver opções</span>
-          </a>
-          <a class="landing-overview__card" href="manicures.html">
-            <span class="landing-overview__eyebrow">Profissionais</span>
-            <h3>Manicures parceiras verificadas</h3>
-            <p>Descubra quem está na rede NailNow e como selecionamos cada especialista.</p>
-            <span class="landing-overview__cta">Conhecer rede</span>
-          </a>
-          <a class="landing-overview__card" href="depoimentos.html">
-            <span class="landing-overview__eyebrow">Depoimentos</span>
-            <h3>Histórias reais das clientes</h3>
-            <p>Leia avaliações completas e experiências marcantes com atendimentos NailNow.</p>
-            <span class="landing-overview__cta">Ler relatos</span>
-          </a>
-          <a class="landing-overview__card" href="faq.html">
-            <span class="landing-overview__eyebrow">FAQ</span>
-            <h3>Dúvidas frequentes respondidas</h3>
-            <p>Encontre respostas sobre deslocamento, pagamento, cancelamentos e seleção de profissionais.</p>
-            <span class="landing-overview__cta">Consultar FAQ</span>
-          </a>
-          <a class="landing-overview__card" href="agendamentos.html">
-            <span class="landing-overview__eyebrow">Minha agenda</span>
-            <h3>Central de agendamentos</h3>
-            <p>Organize compromissos, acompanhe confirmações e receba notificações em tempo real.</p>
-            <span class="landing-overview__cta">Gerenciar horários</span>
-          </a>
-        </div>
-      </section>
-
       <section class="cta-profissional" id="profissionais">
         <div class="cta-content">
           <span class="eyebrow">Para manicures</span>

--- a/styles.css
+++ b/styles.css
@@ -292,11 +292,11 @@ main {
 }
 
 .hero-image-wrapper img {
-  width: 104%;
-  height: 112%;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   display: block;
-  transform: translate(-2%, -6%);
+  transform: none;
 }
 
 .hero-copy {
@@ -306,6 +306,7 @@ main {
   flex-direction: column;
   gap: 1.25rem;
   align-items: flex-start;
+  width: 100%;
 }
 
 .hero-label {
@@ -320,7 +321,7 @@ main {
   background: var(--surface-contrast);
   padding: 0.5rem 1.35rem;
   border-radius: 999px;
-  margin: 0;
+  margin: 0 auto;
   align-self: center;
   border: 1px solid rgba(244, 92, 162, 0.25);
 }
@@ -1364,7 +1365,7 @@ main {
   }
 
   .hero-label {
-    margin: 0;
+    margin: 0 auto;
   }
 
   .hero-media,


### PR DESCRIPTION
## Summary
- remove the landing overview section and its cards from the homepage per request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ca39028c8333b28051f408e35716