### PR TITLE
Adjust header layout for CTA buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -113,19 +113,18 @@ main {
 
 .header-navigation {
   display: flex;
-  align-items: center;
-  gap: clamp(1rem, 3vw, 2rem);
+  flex-direction: column;
+  align-items: flex-end;
+  gap: clamp(0.65rem, 2vw, 1.25rem);
   margin-left: auto;
-  flex-wrap: wrap;
-  justify-content: flex-end;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
   gap: clamp(0.75rem, 2vw, 1.25rem);
-  flex-wrap: wrap;
   justify-content: flex-end;
+  flex-wrap: nowrap;
 }
 
 .brand-mark {


### PR DESCRIPTION
## Summary
- stack the navigation and action blocks vertically within the header so the CTAs sit on the second row
- keep the call-to-action buttons on a single line to prevent wrapping and maintain alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e511db08948333aee0e81a09ccdd5e