### PR TITLE
Insert Canva embed and attribution into /profissional page

### DIFF
--- a/profissional.html
+++ b/profissional.html
@@ -448,6 +448,41 @@
           </div>
         </section>
 
+        <section class="pro-lp__section" aria-label="Apresentação em vídeo">
+          <div
+            style="
+              position: relative;
+              width: 100%;
+              height: 0;
+              padding-top: 56.2225%;
+              padding-bottom: 0;
+              box-shadow: 0 2px 8px 0 rgba(63, 69, 81, 0.16);
+              margin-top: 1.6em;
+              margin-bottom: 0.9em;
+              overflow: hidden;
+              border-radius: 8px;
+              will-change: transform;
+            "
+          >
+            <iframe
+              loading="lazy"
+              style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0; margin: 0"
+              src="https://www.canva.com/design/DAHFdORivM4/4OXaoIlSAQIm4MMrzLK01Q/view?embed"
+              allowfullscreen="allowfullscreen"
+              allow="fullscreen"
+            >
+            </iframe>
+          </div>
+          <a
+            href="https:&#x2F;&#x2F;www.canva.com&#x2F;design&#x2F;DAHFdORivM4&#x2F;4OXaoIlSAQIm4MMrzLK01Q&#x2F;view?utm_content=DAHFdORivM4&amp;utm_campaign=designshare&amp;utm_medium=embeds&amp;utm_source=link"
+            target="_blank"
+            rel="noopener"
+          >
+            O salão retém 50% do seu lucro?
+          </a>
+          de Letícia Lançanova
+        </section>
+
         <section class="pro-lp__section pro-story-step" data-story-step="2" aria-labelledby="dor-title" hidden>
           <h2 id="dor-title">Você já sentiu que trabalha muito e ganha pouco?</h2>
           <p>


### PR DESCRIPTION
### Motivation
- Add the provided Canva embed (responsive iframe + attribution) into the main content of the `/profissional` landing page while keeping header and footer unchanged.

### Description
- Inserted a new `<section class="pro-lp__section" aria-label="Apresentação em vídeo">` directly after the progress section and before the next story section in `profissional.html`.
- The section contains a responsive wrapper with the provided iframe `src="https://www.canva.com/design/DAHFdORivM4/4OXaoIlSAQIm4MMrzLK01Q/view?embed"` and the attribution link and author text as given.
- This is a content-only change affecting only `profissional.html` and does not modify header, footer, or existing scripts and styles.

### Testing
- Ran `git diff --check` and it passed with no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd71ee1888333bacc57fbbdea2d33)