### PR TITLE
Add account deletion page (/excluir-conta) and footer policy link

### DIFF
--- a/agendamentos.html
+++ b/agendamentos.html
@@ -262,6 +262,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/como-funciona.html
+++ b/como-funciona.html
@@ -269,6 +269,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/confirmar-cadastro.html
+++ b/confirmar-cadastro.html
@@ -198,6 +198,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/conteudo.html
+++ b/conteudo.html
@@ -222,6 +222,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/depoimentos.html
+++ b/depoimentos.html
@@ -232,6 +232,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/excluir-conta.html
+++ b/excluir-conta.html
@@ -14,21 +14,21 @@
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Página de cookies e preferências da NailNow." />
+    <meta name="description" content="Exclusão de conta e dados da NailNow." />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://www.nailnow.app/cookies-e-preferencias" />
+    <link rel="canonical" href="https://www.nailnow.app/excluir-conta" />
     <meta property="og:site_name" content="NailNow" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="pt_BR" />
-    <meta property="og:title" content="Cookies e preferências | NailNow" />
-    <meta property="og:description" content="Informações de cookies e preferências da plataforma NailNow." />
-    <meta property="og:url" content="https://www.nailnow.app/cookies-e-preferencias" />
+    <meta property="og:title" content="Exclusão de conta e dados | NailNow" />
+    <meta property="og:description" content="Instruções para solicitar exclusão de conta e dados na NailNow." />
+    <meta property="og:url" content="https://www.nailnow.app/excluir-conta" />
     <meta property="og:image" content="https://www.nailnow.app/assets/nail1.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Cookies e preferências | NailNow" />
-    <meta name="twitter:description" content="Informações de cookies e preferências da plataforma NailNow." />
+    <meta name="twitter:title" content="Exclusão de conta e dados | NailNow" />
+    <meta name="twitter:description" content="Instruções para solicitar exclusão de conta e dados na NailNow." />
     <meta name="twitter:image" content="https://www.nailnow.app/assets/nail1.png" />
-    <title>Cookies e preferências | NailNow</title>
+    <title>Exclusão de conta e dados | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -118,28 +118,45 @@
 
     <main>
       <section class="page-hero">
-        <span class="eyebrow">Cookies</span>
-        <h1>Cookies e preferências</h1>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla laoreet, lorem at pharetra faucibus, neque purus cursus libero.</p>
+        <span class="eyebrow">Suporte</span>
+        <h1>Exclusão de Conta e Dados</h1>
+        <p>Se você deseja excluir sua conta no NailNow e remover todos os seus dados pessoais da nossa plataforma, siga as instruções abaixo.</p>
       </section>
 
       <section class="faq">
         <div class="section-heading">
-          <h2>Configurações e consentimento</h2>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+          <h2>Como solicitar a exclusão</h2>
+          <p>Envie um e-mail para <a href="mailto:suporte@nailnow.app">suporte@nailnow.app</a> com o assunto:</p>
         </div>
         <div class="faq-list" role="list">
           <article class="faq-item" role="listitem">
-            <h3>1. Cookies essenciais</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae ipsum vel dolor viverra luctus. Nulla facilisi. In et justo ut nunc dictum efficitur.</p>
+            <h3>Solicitação de exclusão de conta - NailNow</h3>
+            <p>No corpo do e-mail, informe o endereço de e-mail cadastrado na sua conta.</p>
           </article>
           <article class="faq-item" role="listitem">
-            <h3>2. Cookies de desempenho</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sit amet augue volutpat, ornare augue vitae, tincidunt orci. Quisque ut lectus lectus.</p>
+            <h3>O que será removido</h3>
+            <p>Ao confirmar a exclusão, os seguintes dados serão permanentemente deletados:</p>
+            <ul>
+              <li>Nome, e-mail, telefone e CPF</li>
+              <li>Endereço cadastrado</li>
+              <li>Foto de perfil</li>
+              <li>Histórico de agendamentos</li>
+              <li>Avaliações realizadas</li>
+              <li>Dados de pagamento associados à conta</li>
+            </ul>
+            <p>Para profissionais, também serão removidos: fotos de documento de identidade, fotos de portfólio e informações de serviços.</p>
           </article>
           <article class="faq-item" role="listitem">
-            <h3>3. Gestão de preferências</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur dictum leo id velit feugiat, et convallis urna fermentum. Nunc efficitur sapien nec nunc hendrerit, at dapibus nisl hendrerit.</p>
+            <h3>Prazo</h3>
+            <p>A exclusão será concluída em até 30 dias após a confirmação da solicitação.</p>
+          </article>
+          <article class="faq-item" role="listitem">
+            <h3>Importante</h3>
+            <ul>
+              <li>Esta ação é irreversível.</li>
+              <li>Agendamentos em aberto devem ser cancelados antes da solicitação.</li>
+              <li>Após a exclusão, não será possível recuperar nenhum dado.</li>
+            </ul>
           </article>
         </div>
       </section>
@@ -169,8 +186,8 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
-          <a href="/excluir-conta">Exclusão de conta e dados</a>
-          <a href="/cookies-e-preferencias" aria-current="page">Cookies e preferências</a>
+          <a href="/excluir-conta" aria-current="page">Exclusão de conta e dados</a>
+          <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>
       <p class="footer-copy">© NailNow 2026. Todos os direitos reservados. NAILNOW SERVICOS DIGITAIS LTDA</p>

--- a/faq.html
+++ b/faq.html
@@ -270,6 +270,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -1486,6 +1486,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/manicures.html
+++ b/manicures.html
@@ -241,6 +241,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/politica-de-privacidade.html
+++ b/politica-de-privacidade.html
@@ -234,6 +234,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade" aria-current="page">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/profissional.html
+++ b/profissional.html
@@ -605,6 +605,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-manicure">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/quem-somos.html
+++ b/quem-somos.html
@@ -240,6 +240,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/servicos.html
+++ b/servicos.html
@@ -1325,6 +1325,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/termos-cliente.html
+++ b/termos-cliente.html
@@ -210,6 +210,7 @@
           <h3>Termos & políticas</h3>
           <a href="termos-cliente">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/termos-de-uso.html
+++ b/termos-de-uso.html
@@ -237,6 +237,7 @@
           <h3>Termos & políticas</h3>
           <a href="/termos-de-uso" aria-current="page">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>

--- a/termos-manicure.html
+++ b/termos-manicure.html
@@ -209,6 +209,7 @@
           <h3>Termos & políticas</h3>
           <a href="termos-manicure">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
           <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Provide a dedicated `/excluir-conta` page with clear instructions and legal notices for users who want to delete their NailNow account and data while keeping the same site look-and-feel as the privacy policy. 
- Make the new page discoverable site-wide by adding a persistent footer link `Exclusão de conta e dados` before the `Cookies e preferências` link. 

### Description
- Added a new `excluir-conta.html` page reusing the privacy-policy layout and updated meta/OG/Twitter tags, hero, and main content with the requested deletion instructions, list of data to be removed, timeline, and important warnings. 
- Inserted the footer link `<a href="/excluir-conta">Exclusão de conta e dados</a>` before the cookies link across multiple pages (for example `index.html`, `faq.html`, `politica-de-privacidade.html` and other institutional pages). 
- Marked the footer entry on the new page with `aria-current="page"` and corrected canonical/OG URLs and minor HTML spacing issues in the generated file. 
- New page is published at `/excluir-conta` and the footer updates were applied to the site templates/pages. 

### Testing
- Ran repository inspection commands `rg --files -g 'AGENTS.md'` and `find .. -name AGENTS.md -print` and they completed successfully. 
- Verified the new file with `nl -ba excluir-conta.html` and located updated footer links with `rg -n "excluir-conta|Termos & políticas" *.html`, both checks succeeded. 
- Ran `git status --short` checks and performed commits to record the changes, and the commit operations completed successfully. 
- Created a PR via the internal `make_pr` tool which reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe1c9e2108333bbd4607e4129177c)