### PR TITLE
Update excluir-conta page to describe in-app account deletion flow

### DIFF
--- a/excluir-conta.html
+++ b/excluir-conta.html
@@ -119,44 +119,31 @@
     <main>
       <section class="page-hero">
         <span class="eyebrow">Suporte</span>
-        <h1>Exclusão de Conta e Dados</h1>
-        <p>Se você deseja excluir sua conta no NailNow e remover todos os seus dados pessoais da nossa plataforma, siga as instruções abaixo.</p>
+        <h1>Excluir sua conta NailNow</h1>
+        <p>Você pode excluir sua conta diretamente pelo aplicativo NailNow, a qualquer momento, sem precisar entrar em contato com o suporte.</p>
       </section>
 
       <section class="faq">
         <div class="section-heading">
-          <h2>Como solicitar a exclusão</h2>
-          <p>Envie um e-mail para <a href="mailto:suporte@nailnow.app">suporte@nailnow.app</a> com o assunto:</p>
+          <h2><span style="white-space: nowrap;">Como excluir sua conta pelo app:</span></h2>
         </div>
         <div class="faq-list" role="list">
           <article class="faq-item" role="listitem">
-            <h3>Solicitação de exclusão de conta - NailNow</h3>
-            <p>No corpo do e-mail, informe o endereço de e-mail cadastrado na sua conta.</p>
+            <ol>
+              <li>Abra o aplicativo NailNow</li>
+              <li>Acesse seu Perfil</li>
+              <li>Role até o final da página</li>
+              <li>Toque em "Excluir minha conta"</li>
+              <li>Confirme a exclusão na janela que aparecer</li>
+            </ol>
           </article>
           <article class="faq-item" role="listitem">
-            <h3>O que será removido</h3>
-            <p>Ao confirmar a exclusão, os seguintes dados serão permanentemente deletados:</p>
-            <ul>
-              <li>Nome, e-mail, telefone e CPF</li>
-              <li>Endereço cadastrado</li>
-              <li>Foto de perfil</li>
-              <li>Histórico de agendamentos</li>
-              <li>Avaliações realizadas</li>
-              <li>Dados de pagamento associados à conta</li>
-            </ul>
-            <p>Para profissionais, também serão removidos: fotos de documento de identidade, fotos de portfólio e informações de serviços.</p>
+            <p>Sua conta e todos os seus dados serão excluídos imediatamente.</p>
+            <p>Agendamentos futuros serão cancelados. Esta ação não pode ser desfeita.</p>
           </article>
           <article class="faq-item" role="listitem">
-            <h3>Prazo</h3>
-            <p>A exclusão será concluída em até 30 dias após a confirmação da solicitação.</p>
-          </article>
-          <article class="faq-item" role="listitem">
-            <h3>Importante</h3>
-            <ul>
-              <li>Esta ação é irreversível.</li>
-              <li>Agendamentos em aberto devem ser cancelados antes da solicitação.</li>
-              <li>Após a exclusão, não será possível recuperar nenhum dado.</li>
-            </ul>
+            <h3>Precisa de ajuda?</h3>
+            <p>Entre em contato pelo e-mail <a href="mailto:suporte@nailnow.app">suporte@nailnow.app</a></p>
           </article>
         </div>
       </section>


### PR DESCRIPTION
### Motivation

- Replace an email-based deletion process with instructions for deleting the account directly in the app to match the product's in-app flow.

### Description

- Updated `excluir-conta.html` to change the page title and lead paragraph to `Excluir sua conta NailNow` and emphasize in-app deletion.  
- Replaced the email request section with a step-by-step ordered list showing how to delete the account from the app's Profile.  
- Simplified the data removal section to state immediate deletion and cancellation of future appointments, and removed the detailed list of deleted fields and the 30-day timeline.  
- Replaced the previous "Important"/"Prazo" items with a "Precisa de ajuda?" block that points to `suporte@nailnow.app`.

### Testing

- No automated tests were run for this HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0769c122808333a9271f95cc8d7093)