### PR TITLE
Replace booking form with app download card and add styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1272,107 +1272,16 @@
               </span>
             </h1>
             <p>
-              Reserve seu momento e receba atendimento premium no endereço que preferir, com acompanhamento em tempo real pela NailNow.
+              O app NailNow está chegando para transformar sua rotina de beleza com praticidade e segurança.
             </p>
-            <form class="booking-card" aria-label="Buscar profissionais disponíveis" onsubmit="handleBooking(event)">
-              <div class="booking-card__field booking-card__field--location">
-                <label class="booking-card__label" for="booking-location">Local do atendimento</label>
-                <div class="booking-card__control booking-card__control--line">
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon booking-card__icon--leading">
-                    <path
-                      d="M12 2.5a7 7 0 0 0-7 7c0 4.61 6.23 11.19 6.5 11.47.27.27.7.27.97 0 .27-.28 6.53-6.86 6.53-11.47a7 7 0 0 0-7-7Zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Z"
-                    />
-                  </svg>
-                  <input
-                    type="text"
-                    id="booking-location"
-                    class="booking-card__input"
-                    name="location"
-                    placeholder="Digite o endereço do atendimento"
-                    autocomplete="street-address"
-                    enterkeyhint="go"
-                    required
-                  />
-                </div>
-                <input type="hidden" id="booking-location-formatted" name="location_formatted" />
-                <input type="hidden" id="booking-location-place-id" name="location_place_id" />
-                <input type="hidden" id="booking-location-lat" name="location_lat" />
-                <input type="hidden" id="booking-location-lng" name="location_lng" />
-              </div>
-              <div class="booking-card__field booking-card__field--services" id="booking-service-field">
-                <label class="booking-card__label" for="booking-service-toggle">Serviços desejados</label>
-                <div class="booking-card__control">
-                  <button
-                    type="button"
-                    id="booking-service-toggle"
-                    class="booking-card__input booking-card__input--multiselect"
-                    aria-haspopup="listbox"
-                    aria-expanded="false"
-                  >
-                    <span
-                      id="booking-service-summary"
-                      class="booking-card__selection booking-card__selection--empty"
-                    >
-                      Selecione os serviços
-                    </span>
-                  </button>
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                    <path
-                      d="M5.5 3.5A2.5 2.5 0 0 0 3 6v9.5A3.5 3.5 0 0 0 6.5 19h6.76l2.84 2.84a.75.75 0 0 0 1.28-.53V19H17.5A3.5 3.5 0 0 0 21 15.5v-9a3 3 0 0 0-3-3H6.5a1 1 0 0 0-.18.02Zm.18 1.98H18a1.5 1.5 0 0 1 1.5 1.5v8.52a2 2 0 0 1-2 2h-2.02a.75.75 0 0 0-.75.75v1.3l-1.77-1.77a.75.75 0 0 0-.53-.22H6.5A2 2 0 0 1 4.5 15.5V6a1 1 0 0 1 1-1Z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="booking-card__dropdown"
-                  id="booking-service-dropdown"
-                  role="listbox"
-                  aria-multiselectable="true"
-                  tabindex="-1"
-                  hidden
-                >
-                  <ul class="booking-card__options" id="booking-service-options"></ul>
-                </div>
-                <input type="hidden" name="services" id="booking-services" />
-              </div>
-              <div class="booking-card__row">
-                <div class="booking-card__field">
-                  <label class="booking-card__label" for="booking-date">Data</label>
-                  <div class="booking-card__control booking-card__control--compact">
-                    <input type="date" id="booking-date" name="date" class="booking-card__input" />
-                    <button
-                      type="button"
-                      class="booking-card__icon-button"
-                      data-picker-target="booking-date"
-                      aria-label="Abrir seletor de data"
-                    >
-                      <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                        <path
-                          d="M7 2a1 1 0 0 0-1 1v1H5a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3h-1V3a1 1 0 1 0-2 0v1H8V3a1 1 0 0 0-1-1Zm-2 6h14v9a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1Z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div class="booking-card__field">
-                  <label class="booking-card__label" for="booking-time">Horário</label>
-                  <div class="booking-card__control booking-card__control--compact">
-                    <select
-                      id="booking-time"
-                      name="time"
-                      class="booking-card__input booking-card__input--select"
-                      required
-                    ></select>
-                    <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                      <path
-                        d="M12 2.5a9.5 9.5 0 1 0 9.5 9.5A9.5 9.5 0 0 0 12 2.5Zm-.75 4a.75.75 0 0 1 1.5 0v4.19l3.22 1.86a.75.75 0 0 1-.75 1.3l-3.6-2.08a.75.75 0 0 1-.37-.64Z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <button type="submit" class="booking-card__submit">Ver manicures perto de mim</button>
-              <p class="booking-card__feedback" id="booking-feedback" role="status" aria-live="polite"></p>
-            </form>
+            <a class="booking-card booking-card--store" href="#" aria-label="Baixe pelo app">
+              <span class="booking-card__qr-placeholder" aria-hidden="true"></span>
+              <span class="booking-card__store-copy">
+                <strong>Baixe pelo app</strong>
+                <span>Google Play e App Store</span>
+              </span>
+              <span class="booking-card__store-arrow" aria-hidden="true">→</span>
+            </a>
           </div>
         </section>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -40883,6 +40883,63 @@ main {
   box-shadow: var(--shadow-md);
 }
 
+
+.booking-card--store {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.booking-card--store:hover,
+.booking-card--store:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.booking-card__qr-placeholder {
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  background: #111;
+  flex-shrink: 0;
+}
+
+.booking-card__store-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.booking-card__store-copy strong {
+  font-size: 1.05rem;
+  color: #111;
+}
+
+.booking-card__store-copy span {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.booking-card__store-arrow {
+  margin-left: auto;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #111;
+}
+
+@media (max-width: 540px) {
+  .booking-card--store {
+    align-items: flex-start;
+  }
+
+  .booking-card__store-arrow {
+    font-size: 1.3rem;
+  }
+}
+
 .booking-card__row {
   display: grid;
   gap: clamp(0.85rem, 2.5vw, 1.25rem);


### PR DESCRIPTION
### Motivation
- Simplify the homepage hero by promoting the NailNow mobile app instead of the inline booking flow. 
- Prepare the UI for an app-first rollout by removing the in-page booking inputs and surfacing a clear download CTA.

### Description
- Replaced the interactive booking form in `index.html` with a store download card anchor element (`.booking-card.booking-card--store`) and updated the hero copy to `O app NailNow está chegando...`.
- Removed the previous booking form markup including location inputs, service selector, date/time controls, hidden fields, and `onsubmit` handler from the homepage.
- Added CSS rules to `styles.css` for `.booking-card--store`, `.booking-card__qr-placeholder`, `.booking-card__store-copy`, and responsive tweaks to style the new download card and its states.

### Testing
- Ran the project build with `npm run build` to validate HTML/CSS changes and the build completed successfully. 
- No automated unit tests were modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d2b8b9c083338ee69c1c62fe5539)