### PR TITLE
Introduce new `nn-hero` launch hero and remove legacy booking form; add corresponding styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1264,115 +1264,50 @@
       <div class="home-hero-stack">
         <section class="hero hero--home hero--home-fullpage">
           <div class="hero-copy">
-            <span class="hero-label">Seja uma cliente NailNow</span>
-            <h1>
-              Realce sua <em>beleza</em> natural.
-              <span class="hero-headline__subtitle">
-                Manicure e pedicure a domicílio com conforto, segurança e profissionais verificadas.
-              </span>
-            </h1>
-            <p>
-              Reserve seu momento e receba atendimento premium no endereço que preferir, com acompanhamento em tempo real pela NailNow.
-            </p>
-            <form class="booking-card" aria-label="Buscar profissionais disponíveis" onsubmit="handleBooking(event)">
-              <div class="booking-card__field booking-card__field--location">
-                <label class="booking-card__label" for="booking-location">Local do atendimento</label>
-                <div class="booking-card__control booking-card__control--line">
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon booking-card__icon--leading">
-                    <path
-                      d="M12 2.5a7 7 0 0 0-7 7c0 4.61 6.23 11.19 6.5 11.47.27.27.7.27.97 0 .27-.28 6.53-6.86 6.53-11.47a7 7 0 0 0-7-7Zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Z"
-                    />
-                  </svg>
-                  <input
-                    type="text"
-                    id="booking-location"
-                    class="booking-card__input"
-                    name="location"
-                    placeholder="Digite o endereço do atendimento"
-                    autocomplete="street-address"
-                    enterkeyhint="go"
-                    required
-                  />
-                </div>
-                <input type="hidden" id="booking-location-formatted" name="location_formatted" />
-                <input type="hidden" id="booking-location-place-id" name="location_place_id" />
-                <input type="hidden" id="booking-location-lat" name="location_lat" />
-                <input type="hidden" id="booking-location-lng" name="location_lng" />
+            <section class="nn-hero" aria-label="Lançamento do app NailNow">
+              <div class="nn-hero__badge">
+                <span class="nn-hero__badge-dot"></span>
+                Lançamento em Porto Alegre · maio 2026
               </div>
-              <div class="booking-card__field booking-card__field--services" id="booking-service-field">
-                <label class="booking-card__label" for="booking-service-toggle">Serviços desejados</label>
-                <div class="booking-card__control">
-                  <button
-                    type="button"
-                    id="booking-service-toggle"
-                    class="booking-card__input booking-card__input--multiselect"
-                    aria-haspopup="listbox"
-                    aria-expanded="false"
-                  >
-                    <span
-                      id="booking-service-summary"
-                      class="booking-card__selection booking-card__selection--empty"
-                    >
-                      Selecione os serviços
-                    </span>
-                  </button>
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                    <path
-                      d="M5.5 3.5A2.5 2.5 0 0 0 3 6v9.5A3.5 3.5 0 0 0 6.5 19h6.76l2.84 2.84a.75.75 0 0 0 1.28-.53V19H17.5A3.5 3.5 0 0 0 21 15.5v-9a3 3 0 0 0-3-3H6.5a1 1 0 0 0-.18.02Zm.18 1.98H18a1.5 1.5 0 0 1 1.5 1.5v8.52a2 2 0 0 1-2 2h-2.02a.75.75 0 0 0-.75.75v1.3l-1.77-1.77a.75.75 0 0 0-.53-.22H6.5A2 2 0 0 1 4.5 15.5V6a1 1 0 0 1 1-1Z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="booking-card__dropdown"
-                  id="booking-service-dropdown"
-                  role="listbox"
-                  aria-multiselectable="true"
-                  tabindex="-1"
-                  hidden
-                >
-                  <ul class="booking-card__options" id="booking-service-options"></ul>
-                </div>
-                <input type="hidden" name="services" id="booking-services" />
+
+              <h1 class="nn-hero__title">
+                Do seu jeito.<br />
+                <em>No seu tempo.</em>
+              </h1>
+
+              <p class="nn-hero__subtitle">
+                Unhas perfeitas sem sair de casa. Agende pelo app com profissionais verificadas.
+              </p>
+
+              <div class="nn-hero__ctas">
+                <a class="nn-store" href="#" aria-label="Baixe na App Store">
+                  <span class="nn-store__icon" aria-hidden="true"></span>
+                  <span>
+                    <small>Baixe na</small>
+                    <strong>App Store</strong>
+                  </span>
+                </a>
+                <a class="nn-store" href="#" aria-label="Disponível no Google Play">
+                  <span class="nn-store__icon" aria-hidden="true">▶</span>
+                  <span>
+                    <small>Disponível no</small>
+                    <strong>Google Play</strong>
+                  </span>
+                </a>
               </div>
-              <div class="booking-card__row">
-                <div class="booking-card__field">
-                  <label class="booking-card__label" for="booking-date">Data</label>
-                  <div class="booking-card__control booking-card__control--compact">
-                    <input type="date" id="booking-date" name="date" class="booking-card__input" />
-                    <button
-                      type="button"
-                      class="booking-card__icon-button"
-                      data-picker-target="booking-date"
-                      aria-label="Abrir seletor de data"
-                    >
-                      <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                        <path
-                          d="M7 2a1 1 0 0 0-1 1v1H5a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3h-1V3a1 1 0 1 0-2 0v1H8V3a1 1 0 0 0-1-1Zm-2 6h14v9a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1Z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
+
+              <div class="nn-hero__trust">
+                <div class="nn-hero__trust-item">
+                  <span aria-hidden="true">✓</span> Profissionais verificadas
                 </div>
-                <div class="booking-card__field">
-                  <label class="booking-card__label" for="booking-time">Horário</label>
-                  <div class="booking-card__control booking-card__control--compact">
-                    <select
-                      id="booking-time"
-                      name="time"
-                      class="booking-card__input booking-card__input--select"
-                      required
-                    ></select>
-                    <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                      <path
-                        d="M12 2.5a9.5 9.5 0 1 0 9.5 9.5A9.5 9.5 0 0 0 12 2.5Zm-.75 4a.75.75 0 0 1 1.5 0v4.19l3.22 1.86a.75.75 0 0 1-.75 1.3l-3.6-2.08a.75.75 0 0 1-.37-.64Z"
-                      />
-                    </svg>
-                  </div>
+                <div class="nn-hero__trust-item">
+                  <span aria-hidden="true">🔒</span> Pagamento seguro
+                </div>
+                <div class="nn-hero__trust-item">
+                  <span aria-hidden="true">🏠</span> Atendimento a domicílio
                 </div>
               </div>
-              <button type="submit" class="booking-card__submit">Ver manicures perto de mim</button>
-              <p class="booking-card__feedback" id="booking-feedback" role="status" aria-live="polite"></p>
-            </form>
+            </section>
           </div>
         </section>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -40883,6 +40883,63 @@ main {
   box-shadow: var(--shadow-md);
 }
 
+
+.booking-card--store {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.booking-card--store:hover,
+.booking-card--store:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.booking-card__qr-placeholder {
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  background: #111;
+  flex-shrink: 0;
+}
+
+.booking-card__store-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.booking-card__store-copy strong {
+  font-size: 1.05rem;
+  color: #111;
+}
+
+.booking-card__store-copy span {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.booking-card__store-arrow {
+  margin-left: auto;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #111;
+}
+
+@media (max-width: 540px) {
+  .booking-card--store {
+    align-items: flex-start;
+  }
+
+  .booking-card__store-arrow {
+    font-size: 1.3rem;
+  }
+}
+
 .booking-card__row {
   display: grid;
   gap: clamp(0.85rem, 2.5vw, 1.25rem);
@@ -44035,5 +44092,138 @@ body.portal .request-toolbar {
 
   .whatsapp-widget__text {
     display: none;
+  }
+}
+
+.nn-hero {
+  padding: 120px 28px 100px;
+  text-align: center;
+  font-family: 'Inter', sans-serif;
+}
+
+.nn-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #ffe3f1;
+  color: #814d68;
+  padding: 7px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 32px;
+}
+
+.nn-hero__badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f45ca2;
+}
+
+.nn-hero__title {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 80px;
+  line-height: 1;
+  color: #814d68;
+  margin: 0 0 24px;
+  font-weight: 400;
+  letter-spacing: -2.5px;
+}
+
+.nn-hero__title em {
+  color: #f45ca2;
+  font-style: italic;
+}
+
+.nn-hero__subtitle {
+  font-size: 18px;
+  line-height: 1.6;
+  color: #814d68;
+  margin: 0 auto 48px;
+  max-width: 520px;
+}
+
+.nn-hero__ctas {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 40px;
+}
+
+.nn-store {
+  background: #814d68;
+  color: #fff;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-family: 'Inter', sans-serif;
+  text-decoration: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+}
+
+.nn-store__icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.nn-store small {
+  display: block;
+  font-size: 10px;
+  opacity: 0.8;
+  font-weight: 400;
+  line-height: 1;
+  margin-bottom: 2px;
+}
+
+.nn-store strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.nn-hero__trust {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 32px;
+  font-size: 13px;
+  color: #814d68;
+  flex-wrap: wrap;
+}
+
+.nn-hero__trust-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 640px) {
+  .nn-hero {
+    padding: 64px 20px 56px;
+  }
+
+  .nn-hero__title {
+    font-size: 48px;
+    letter-spacing: -1.5px;
+  }
+
+  .nn-hero__subtitle {
+    font-size: 16px;
+  }
+
+  .nn-hero__ctas {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .nn-hero__trust {
+    gap: 16px;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
### Motivation
- Replace the homepage booking-card hero with a marketing-focused launch hero for the NailNow app rollout in Porto Alegre (May 2026).
- Simplify the top-of-page experience by removing the interactive booking form and emphasizing app download CTAs and trust signals.

### Description
- Replaced the original booking form markup in `index.html` with a new `<section class="nn-hero">` containing a launch badge, headline, subtitle, app store CTAs, and trust items. 
- Removed the booking `form` and its location/date/time/service input elements from the hero area in `index.html`.
- Added comprehensive styles in `styles.css` for `.nn-hero`, `.nn-store`, `.nn-hero__trust` and responsive adjustments, and introduced a `booking-card--store` variant with QR/store layout helpers.
- Kept surrounding sections (header, instagram feed) intact while altering the hero layout and visual presentation.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d2b8b9c083338ee69c1c62fe5539)