### PR TITLE
Replace booking hero with app launch hero and add new hero/store styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1264,115 +1264,45 @@
       <div class="home-hero-stack">
         <section class="hero hero--home hero--home-fullpage">
           <div class="hero-copy">
-            <span class="hero-label">Seja uma cliente NailNow</span>
-            <h1>
-              Realce sua <em>beleza</em> natural.
-              <span class="hero-headline__subtitle">
-                Manicure e pedicure a domicílio com conforto, segurança e profissionais verificadas.
-              </span>
-            </h1>
-            <p>
-              Reserve seu momento e receba atendimento premium no endereço que preferir, com acompanhamento em tempo real pela NailNow.
-            </p>
-            <form class="booking-card" aria-label="Buscar profissionais disponíveis" onsubmit="handleBooking(event)">
-              <div class="booking-card__field booking-card__field--location">
-                <label class="booking-card__label" for="booking-location">Local do atendimento</label>
-                <div class="booking-card__control booking-card__control--line">
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon booking-card__icon--leading">
-                    <path
-                      d="M12 2.5a7 7 0 0 0-7 7c0 4.61 6.23 11.19 6.5 11.47.27.27.7.27.97 0 .27-.28 6.53-6.86 6.53-11.47a7 7 0 0 0-7-7Zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5Z"
-                    />
-                  </svg>
-                  <input
-                    type="text"
-                    id="booking-location"
-                    class="booking-card__input"
-                    name="location"
-                    placeholder="Digite o endereço do atendimento"
-                    autocomplete="street-address"
-                    enterkeyhint="go"
-                    required
-                  />
-                </div>
-                <input type="hidden" id="booking-location-formatted" name="location_formatted" />
-                <input type="hidden" id="booking-location-place-id" name="location_place_id" />
-                <input type="hidden" id="booking-location-lat" name="location_lat" />
-                <input type="hidden" id="booking-location-lng" name="location_lng" />
+            <section class="nn-hero" aria-label="Lançamento do app NailNow">
+              <h1 class="nn-hero__title">
+                Do seu jeito.<br />
+                <em>No seu tempo.</em>
+              </h1>
+
+              <p class="nn-hero__subtitle">
+                Unhas perfeitas sem sair de casa. Agende pelo app com profissionais verificadas.
+              </p>
+
+              <div class="nn-hero__ctas">
+                <a class="nn-store" href="#" aria-label="Baixe na App Store">
+                  <span class="nn-store__icon" aria-hidden="true"></span>
+                  <span>
+                    <small>Baixe na</small>
+                    <strong>App Store</strong>
+                  </span>
+                </a>
+                <a class="nn-store" href="#" aria-label="Disponível no Google Play">
+                  <span class="nn-store__icon" aria-hidden="true">▶</span>
+                  <span>
+                    <small>Disponível no</small>
+                    <strong>Google Play</strong>
+                  </span>
+                </a>
               </div>
-              <div class="booking-card__field booking-card__field--services" id="booking-service-field">
-                <label class="booking-card__label" for="booking-service-toggle">Serviços desejados</label>
-                <div class="booking-card__control">
-                  <button
-                    type="button"
-                    id="booking-service-toggle"
-                    class="booking-card__input booking-card__input--multiselect"
-                    aria-haspopup="listbox"
-                    aria-expanded="false"
-                  >
-                    <span
-                      id="booking-service-summary"
-                      class="booking-card__selection booking-card__selection--empty"
-                    >
-                      Selecione os serviços
-                    </span>
-                  </button>
-                  <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                    <path
-                      d="M5.5 3.5A2.5 2.5 0 0 0 3 6v9.5A3.5 3.5 0 0 0 6.5 19h6.76l2.84 2.84a.75.75 0 0 0 1.28-.53V19H17.5A3.5 3.5 0 0 0 21 15.5v-9a3 3 0 0 0-3-3H6.5a1 1 0 0 0-.18.02Zm.18 1.98H18a1.5 1.5 0 0 1 1.5 1.5v8.52a2 2 0 0 1-2 2h-2.02a.75.75 0 0 0-.75.75v1.3l-1.77-1.77a.75.75 0 0 0-.53-.22H6.5A2 2 0 0 1 4.5 15.5V6a1 1 0 0 1 1-1Z"
-                    />
-                  </svg>
+
+              <div class="nn-hero__trust">
+                <div class="nn-hero__trust-item">
+                  <span aria-hidden="true">✓</span> Profissionais verificadas
                 </div>
-                <div
-                  class="booking-card__dropdown"
-                  id="booking-service-dropdown"
-                  role="listbox"
-                  aria-multiselectable="true"
-                  tabindex="-1"
-                  hidden
-                >
-                  <ul class="booking-card__options" id="booking-service-options"></ul>
+                <div class="nn-hero__trust-item">
+                  <span aria-hidden="true">🔒</span> Pagamento seguro
                 </div>
-                <input type="hidden" name="services" id="booking-services" />
-              </div>
-              <div class="booking-card__row">
-                <div class="booking-card__field">
-                  <label class="booking-card__label" for="booking-date">Data</label>
-                  <div class="booking-card__control booking-card__control--compact">
-                    <input type="date" id="booking-date" name="date" class="booking-card__input" />
-                    <button
-                      type="button"
-                      class="booking-card__icon-button"
-                      data-picker-target="booking-date"
-                      aria-label="Abrir seletor de data"
-                    >
-                      <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                        <path
-                          d="M7 2a1 1 0 0 0-1 1v1H5a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3h-1V3a1 1 0 1 0-2 0v1H8V3a1 1 0 0 0-1-1Zm-2 6h14v9a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1Z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div class="booking-card__field">
-                  <label class="booking-card__label" for="booking-time">Horário</label>
-                  <div class="booking-card__control booking-card__control--compact">
-                    <select
-                      id="booking-time"
-                      name="time"
-                      class="booking-card__input booking-card__input--select"
-                      required
-                    ></select>
-                    <svg viewBox="0 0 24 24" aria-hidden="true" class="booking-card__icon">
-                      <path
-                        d="M12 2.5a9.5 9.5 0 1 0 9.5 9.5A9.5 9.5 0 0 0 12 2.5Zm-.75 4a.75.75 0 0 1 1.5 0v4.19l3.22 1.86a.75.75 0 0 1-.75 1.3l-3.6-2.08a.75.75 0 0 1-.37-.64Z"
-                      />
-                    </svg>
-                  </div>
+                <div class="nn-hero__trust-item">
+                  <span aria-hidden="true">🏠</span> Atendimento a domicílio
                 </div>
               </div>
-              <button type="submit" class="booking-card__submit">Ver manicures perto de mim</button>
-              <p class="booking-card__feedback" id="booking-feedback" role="status" aria-live="polite"></p>
-            </form>
+            </section>
           </div>
         </section>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -40308,32 +40308,31 @@ main {
 
 .hero--home-fullpage {
   position: relative;
-  min-height: calc(100vh - 150px);
+  min-height: clamp(560px, 78vh, 760px);
   width: min(100%, 1280px);
   border-radius: 0;
-  padding: clamp(2.5rem, 6vw, 5rem) clamp(1.2rem, 4vw, 3rem);
+  padding: clamp(2rem, 5vw, 3.25rem) clamp(1.2rem, 4vw, 3rem);
   display: grid;
   place-items: center;
   overflow: hidden;
-  background:
-    linear-gradient(180deg, rgba(24, 15, 20, 0.52), rgba(24, 15, 20, 0.58)),
-    url("assets/nail1.png") center / cover no-repeat;
+  background: linear-gradient(180deg, rgba(250, 232, 242, 0.72), rgba(248, 221, 236, 0.78));
   box-shadow: none;
   border: 0;
 }
 
 .hero--home-fullpage::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 70% 45%, rgba(255, 224, 238, 0.28), transparent 52%);
-  pointer-events: none;
+  content: none;
 }
 
 .hero--home.hero--home-fullpage .hero-copy {
   position: relative;
   z-index: 1;
-  width: min(100%, 880px);
+  width: min(100%, 1080px);
+  margin: 0 auto;
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   align-items: center;
 }
@@ -40881,6 +40880,63 @@ main {
   margin-top: 0;
   width: min(100%, 520px);
   box-shadow: var(--shadow-md);
+}
+
+
+.booking-card--store {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.booking-card--store:hover,
+.booking-card--store:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.booking-card__qr-placeholder {
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  background: #111;
+  flex-shrink: 0;
+}
+
+.booking-card__store-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.booking-card__store-copy strong {
+  font-size: 1.05rem;
+  color: #111;
+}
+
+.booking-card__store-copy span {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.booking-card__store-arrow {
+  margin-left: auto;
+  font-size: 1.6rem;
+  line-height: 1;
+  color: #111;
+}
+
+@media (max-width: 540px) {
+  .booking-card--store {
+    align-items: flex-start;
+  }
+
+  .booking-card__store-arrow {
+    font-size: 1.3rem;
+  }
 }
 
 .booking-card__row {
@@ -44035,5 +44091,150 @@ body.portal .request-toolbar {
 
   .whatsapp-widget__text {
     display: none;
+  }
+}
+
+.nn-hero {
+  width: min(100%, 1080px);
+  margin: 0 auto;
+  min-height: clamp(500px, 68vh, 700px);
+  padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 3vw, 3rem);
+  text-align: center;
+  font-family: 'Inter', sans-serif;
+  background: rgba(129, 77, 104, 0.92);
+  border: 1px solid rgba(255, 227, 241, 0.45);
+  border-radius: 28px;
+  box-shadow: 0 30px 70px -40px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.nn-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #ffe3f1;
+  color: #814d68;
+  padding: 7px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 32px;
+}
+
+.nn-hero__badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f45ca2;
+}
+
+.nn-hero__title {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: clamp(3.6rem, 8vw, 6rem);
+  line-height: 1;
+  color: #fff;
+  margin: 0 0 24px;
+  font-weight: 400;
+  letter-spacing: -2.5px;
+}
+
+.nn-hero__title em {
+  color: #ffd3e9;
+  font-style: italic;
+}
+
+.nn-hero__subtitle {
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(255, 244, 250, 0.94);
+  margin: 0 auto 48px;
+  max-width: 520px;
+}
+
+.nn-hero__ctas {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 40px;
+}
+
+.nn-store {
+  background: #fff;
+  color: #814d68;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-family: 'Inter', sans-serif;
+  text-decoration: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+}
+
+.nn-store__icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.nn-store small {
+  display: block;
+  font-size: 10px;
+  opacity: 0.8;
+  font-weight: 400;
+  line-height: 1;
+  margin-bottom: 2px;
+}
+
+.nn-store strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.nn-hero__trust {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 32px;
+  font-size: 13px;
+  color: #fff;
+  flex-wrap: wrap;
+}
+
+.nn-hero__trust-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@media (max-width: 640px) {
+  .nn-hero {
+    width: min(100%, 94vw);
+    padding: 2rem 1.1rem;
+    border-radius: 20px;
+  }
+
+  .nn-hero__title {
+    font-size: 48px;
+    letter-spacing: -1.5px;
+  }
+
+  .nn-hero__subtitle {
+    font-size: 16px;
+  }
+
+  .nn-hero__ctas {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .nn-hero__trust {
+    gap: 16px;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
### Motivation
- Replace the existing on-page booking card hero with a focused app launch hero to promote the NailNow app and downloads.  
- Simplify the homepage hero content and visual hierarchy by removing the multi-field booking form and emphasizing CTAs and trust signals.  
- Update layout and responsive sizing to better center content and improve mobile experience.

### Description
- Removed the in-hero booking `form` and its inputs/options and introduced a new `section` with class `nn-hero` that contains a title, subtitle, app store CTAs, and trust items.  
- Replaced the previous background image and radial overlay with a soft gradient and adjusted `.hero--home-fullpage` sizing, padding, centering, and text alignment.  
- Added a set of new CSS rules for `.nn-hero`, `.nn-store`, `.nn-hero__trust`, and related elements to style the app launch card and made responsive adjustments for smaller viewports.  
- Introduced `booking-card--store`, QR placeholder and store-copy styles to support alternate store-download presentation while preserving existing `.booking-card` rules.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d2b8b9c083338ee69c1c62fe5539)