### PR TITLE
Simplify hero markup in index.html by removing redundant wrappers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,12 +1261,9 @@
     </header>
 
     <main>
-      <div class="home-hero-stack">
-        <section class="hero hero--home hero--home-fullpage">
-          <div class="hero-copy">
-            <section class="nn-hero" aria-label="Lançamento do app NailNow">
-              <div class="nn-hero__layout">
-                <div class="nn-hero__content">
+      <section class="nn-hero" aria-label="Lançamento do app NailNow">
+        <div class="nn-hero__layout">
+          <div class="nn-hero__content">
                   <h1 class="nn-hero__title">
                     Do seu jeito.<br />
                     <em>No seu tempo.</em>
@@ -1304,15 +1301,12 @@
                       <span aria-hidden="true">🏠</span> Atendimento a domicílio
                     </div>
                   </div>
-                </div>
-                <div class="nn-hero__image-wrap">
-                  <img class="nn-hero__image" src="assets/nail1.png" alt="Manicure NailNow atendendo cliente" loading="lazy" />
-                </div>
-              </div>
-            </section>
           </div>
-        </section>
-      </div>
+          <div class="nn-hero__image-wrap">
+            <img class="nn-hero__image" src="assets/nail1.png" alt="Manicure NailNow atendendo cliente" loading="lazy" />
+          </div>
+        </div>
+      </section>
 
     <section class="instagram-feed-strip" aria-label="Feed do Instagram da NailNow">
       <div class="instagram-feed-strip__inner">


### PR DESCRIPTION
### Motivation
- Reduce unnecessary DOM nesting in the homepage hero to simplify markup and make styling/layout easier by removing duplicate wrapper elements around the hero section.

### Description
- Removed the outer `div.home-hero-stack` and the extra `section.hero hero--home hero--home-fullpage` wrapper and flattened the hero markup into a single `section.nn-hero` in `index.html`.
- Repositioned the hero content and image containers so the existing `.nn-hero__content` and `.nn-hero__image-wrap` remain but under a simplified parent structure, preserving text, CTAs, and the image `assets/nail1.png`.
- Adjusted surrounding closing tags and indentation to match the new structure without changing visible copy or attributes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09000017848333aaf73ed851e49dec)