### PR TITLE
Stop forced Firebase auth on catalog load and harden B2B form submission to `b2b` collection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,19 +1261,16 @@
     </header>
 
     <main>
-      <div class="home-hero-stack">
-        <section class="hero hero--home hero--home-fullpage">
-          <div class="hero-copy">
-            <section class="nn-hero" aria-label="Lançamento do app NailNow">
-              <div class="nn-hero__layout">
-                <div class="nn-hero__content">
+      <section class="nn-hero" aria-label="Lançamento do app NailNow">
+        <div class="nn-hero__layout">
+          <div class="nn-hero__content">
                   <h1 class="nn-hero__title">
                     Do seu jeito.<br />
                     <em>No seu tempo.</em>
                   </h1>
 
                   <p class="nn-hero__subtitle">
-                    Unhas perfeitas sem sair de casa. Agende pelo app com profissionais verificadas.
+                    <br />Unhas perfeitas sem sair de casa.<br />Agende pelo app com profissionais verificadas.
                   </p>
 
                   <div class="nn-hero__ctas">
@@ -1293,26 +1290,79 @@
                     </a>
                   </div>
 
-                  <div class="nn-hero__trust">
-                    <div class="nn-hero__trust-item">
-                      <span aria-hidden="true">✓</span> Profissionais verificadas
-                    </div>
-                    <div class="nn-hero__trust-item">
-                      <span aria-hidden="true">🔒</span> Pagamento seguro
-                    </div>
-                    <div class="nn-hero__trust-item">
-                      <span aria-hidden="true">🏠</span> Atendimento a domicílio
-                    </div>
-                  </div>
-                </div>
-                <div class="nn-hero__image-wrap">
-                  <img class="nn-hero__image" src="assets/nail1.png" alt="Manicure NailNow atendendo cliente" loading="lazy" />
-                </div>
-              </div>
-            </section>
           </div>
-        </section>
-      </div>
+          <div class="nn-hero__image-wrap">
+            <img class="nn-hero__image" src="assets/nail1.png" alt="Manicure NailNow atendendo cliente" loading="lazy" />
+          </div>
+        </div>
+
+        <div class="nn-hero__trust" role="list" aria-label="Diferenciais NailNow">
+          <div class="nn-hero__trust-item" role="listitem">
+            <span aria-hidden="true">✓</span>
+            <span>Profissionais verificadas</span>
+          </div>
+          <div class="nn-hero__trust-item" role="listitem">
+            <span aria-hidden="true">🔒</span>
+            <span>Pagamento seguro</span>
+          </div>
+          <div class="nn-hero__trust-item" role="listitem">
+            <span aria-hidden="true">🏠</span>
+            <span>Atendimento a domicílio</span>
+          </div>
+        </div>
+      </section>
+
+    <section class="nn-b2b-wrap" aria-label="NailNow para empresas">
+        <div class="nn-b2b-card" id="nn-form-card">
+          <div class="nn-b2b-eyebrow">
+            <span class="dot" aria-hidden="true"></span>
+            NailNow para empresas
+          </div>
+
+          <h2 class="nn-b2b-title">Beleza como<br /><em>benefício corporativo.</em></h2>
+
+          <p class="nn-b2b-sub">
+            Oferecer cuidado às suas colaboradoras nunca foi tão simples. Conte para a gente sobre sua empresa e nosso time entra em contato.
+          </p>
+
+          <form id="nn-b2b-form" novalidate>
+            <div class="nn-field">
+              <label class="nn-label" for="nn-nome">Nome completo</label>
+              <input class="nn-input" id="nn-nome" name="nome" type="text" placeholder="Como podemos te chamar?" required />
+            </div>
+
+            <div class="nn-row">
+              <div class="nn-field">
+                <label class="nn-label" for="nn-celular">Celular</label>
+                <input class="nn-input" id="nn-celular" name="celular" type="tel" placeholder="(11) 99999-9999" maxlength="15" required />
+              </div>
+              <div class="nn-field">
+                <label class="nn-label" for="nn-email">E-mail corporativo</label>
+                <input class="nn-input" id="nn-email" name="email" type="email" placeholder="voce@empresa.com" required />
+              </div>
+            </div>
+
+            <div class="nn-field">
+              <label class="nn-label" for="nn-empresa">Empresa</label>
+              <input class="nn-input" id="nn-empresa" name="empresa" type="text" placeholder="Nome da empresa" required />
+            </div>
+
+            <div class="nn-field">
+              <label class="nn-label" for="nn-cnpj">CNPJ</label>
+              <input class="nn-input" id="nn-cnpj" name="cnpj" type="text" placeholder="00.000.000/0000-00" maxlength="18" required />
+            </div>
+
+            <button type="submit" class="nn-cta-pill" id="nn-submit-btn">Enviar Solicitação</button>
+
+            <div id="nn-error" class="nn-error-msg" style="display:none;"></div>
+
+            <p class="nn-disclaimer">
+              Ao enviar, você concorda com nossa política de privacidade.<br />
+              Sem spam — só respondemos quando faz sentido.
+            </p>
+          </form>
+        </div>
+      </section>
 
     <section class="instagram-feed-strip" aria-label="Feed do Instagram da NailNow">
       <div class="instagram-feed-strip__inner">
@@ -1382,9 +1432,12 @@
           </header>
           <ul class="match-results__list" id="match-results-list" role="list"></ul>
         </div>
+
       </section>
 
 
+
+      
 
       <section class="cta-profissional" id="profissionais">
         <div class="cta-content">
@@ -1444,6 +1497,8 @@
         getFirestore,
         collection,
         getDocs,
+        addDoc,
+        serverTimestamp,
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
       const firebaseConfig = {
@@ -1550,6 +1605,28 @@
         }
 
         return authReadyPromise;
+      }
+
+
+      async function saveB2BLead(payload) {
+        const writeAttempt = async () => addDoc(collection(db, "b2b"), payload);
+
+        try {
+          return await writeAttempt();
+        } catch (error) {
+          if (error?.code !== "permission-denied") {
+            throw error;
+          }
+
+          try {
+            await ensureAnonymousAccess();
+          } catch (authError) {
+            authError.message = "auth-failed:" + (authError.message || "");
+            throw authError;
+          }
+
+          return writeAttempt();
+        }
       }
 
       let selectedServices = new Set();
@@ -2243,14 +2320,6 @@
 
         professionalsReadyPromise = (async () => {
           professionalsLoadError = null;
-          try {
-            await ensureAnonymousAccess();
-          } catch (error) {
-            professionalCatalog = [];
-            populateServiceSelect();
-            professionalsLoadError = error;
-            throw error;
-          }
           const sources = [{ path: "profissionais", label: "profissionais" }];
 
           let mergedCatalog = [];
@@ -3035,13 +3104,101 @@
             }
           });
         }
-        ensureAnonymousAccess().catch((error) => {
-          console.error("Erro ao preparar autenticação anônima", error);
-        });
         ensureProfessionalsLoaded().catch((error) => {
           console.error("Erro inicial ao carregar profissionais", error);
         });
         initBookingPickerButtons();
+
+        const nnB2BForm = document.getElementById("nn-b2b-form");
+        if (nnB2BForm) {
+          const maskPhone = (v) => {
+            v = v.replace(/\D/g, "").slice(0, 11);
+            if (v.length > 10) return v.replace(/(\d{2})(\d{5})(\d{0,4}).*/, "($1) $2-$3");
+            if (v.length > 6) return v.replace(/(\d{2})(\d{4})(\d{0,4}).*/, "($1) $2-$3");
+            if (v.length > 2) return v.replace(/(\d{2})(\d{0,5}).*/, "($1) $2");
+            if (v.length > 0) return v.replace(/(\d{0,2}).*/, "($1");
+            return "";
+          };
+          const maskCNPJ = (v) => {
+            v = v.replace(/\D/g, "").slice(0, 14);
+            v = v.replace(/^(\d{2})(\d)/, "$1.$2");
+            v = v.replace(/^(\d{2})\.(\d{3})(\d)/, "$1.$2.$3");
+            v = v.replace(/\.(\d{3})(\d)/, ".$1/$2");
+            v = v.replace(/(\d{4})(\d)/, "$1-$2");
+            return v;
+          };
+          const isValidEmail = (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+          const isValidCNPJ = (cnpjValue) => {
+            const cnpj = cnpjValue.replace(/\D/g, "");
+            if (cnpj.length !== 14 || /^(\d)\1+$/.test(cnpj)) return false;
+            let t = cnpj.length - 2; let n = cnpj.substring(0, t); const d = cnpj.substring(t);
+            let s = 0; let m = t - 7;
+            for (let i = t; i >= 1; i -= 1) { s += Number(n.charAt(t - i)) * m; m -= 1; if (m < 2) m = 9; }
+            let r = s % 11 < 2 ? 0 : 11 - (s % 11);
+            if (r !== Number(d.charAt(0))) return false;
+            t += 1; n = cnpj.substring(0, t); s = 0; m = t - 7;
+            for (let i = t; i >= 1; i -= 1) { s += Number(n.charAt(t - i)) * m; m -= 1; if (m < 2) m = 9; }
+            r = s % 11 < 2 ? 0 : 11 - (s % 11);
+            return r === Number(d.charAt(1));
+          };
+
+          const inputs = {
+            nome: document.getElementById("nn-nome"), celular: document.getElementById("nn-celular"), email: document.getElementById("nn-email"), empresa: document.getElementById("nn-empresa"), cnpj: document.getElementById("nn-cnpj"),
+          };
+          const btn = document.getElementById("nn-submit-btn");
+          const errBox = document.getElementById("nn-error");
+          const formCard = document.getElementById("nn-form-card");
+          inputs.celular?.addEventListener("input", (e) => { e.target.value = maskPhone(e.target.value); });
+          inputs.cnpj?.addEventListener("input", (e) => { e.target.value = maskCNPJ(e.target.value); });
+
+          const validateB2B = () => {
+            let ok = true;
+            Object.values(inputs).forEach((i) => i?.classList.remove("is-error"));
+            if (!inputs.nome.value.trim() || inputs.nome.value.trim().split(" ").length < 2) { inputs.nome.classList.add("is-error"); ok = false; }
+            if (inputs.celular.value.replace(/\D/g, "").length < 10) { inputs.celular.classList.add("is-error"); ok = false; }
+            if (!isValidEmail(inputs.email.value)) { inputs.email.classList.add("is-error"); ok = false; }
+            if (!inputs.empresa.value.trim()) { inputs.empresa.classList.add("is-error"); ok = false; }
+            if (!isValidCNPJ(inputs.cnpj.value)) { inputs.cnpj.classList.add("is-error"); ok = false; }
+            return ok;
+          };
+
+          nnB2BForm.addEventListener("submit", async (e) => {
+            e.preventDefault();
+            if (errBox) errBox.style.display = "none";
+            if (!validateB2B()) {
+              if (errBox) { errBox.textContent = "Por favor, confira os campos destacados."; errBox.style.display = "block"; }
+              return;
+            }
+            btn.disabled = true;
+            btn.innerHTML = '<span class="nn-spinner"></span> Enviando...';
+            try {
+              await saveB2BLead({
+                nome: inputs.nome.value.trim(), celular: inputs.celular.value, celularRaw: inputs.celular.value.replace(/\D/g, ""),
+                email: inputs.email.value.trim().toLowerCase(), empresa: inputs.empresa.value.trim(), cnpj: inputs.cnpj.value, cnpjRaw: inputs.cnpj.value.replace(/\D/g, ""),
+                origem: "site_b2b", status: "novo", createdAt: serverTimestamp(), userAgent: navigator.userAgent,
+              });
+              const firstName = inputs.nome.value.trim().split(" ")[0];
+              const empresa = inputs.empresa.value.trim();
+              formCard.innerHTML = `<div class="nn-success"><div class="nn-success-icon">✓</div><h2 class="nn-b2b-title" style="margin-bottom:8px;">Recebido, <em>${firstName}!</em></h2><p class="nn-b2b-sub" style="margin-bottom:0;">Nosso time entra em contato com a <strong>${empresa}</strong> em até 1 dia útil.</p></div>`;
+            } catch (err) {
+              console.error("Erro ao salvar lead:", err);
+              btn.disabled = false;
+              btn.textContent = "Enviar Solicitação";
+              if (errBox) {
+                const code = err?.code || "";
+                const message = String(err?.message || "");
+                if (message.startsWith("auth-failed:")) {
+                  errBox.textContent = "Não foi possível autenticar no Firebase. Ative o login anônimo em Authentication > Sign-in method e tente novamente.";
+                } else if (code.includes("permission-denied")) {
+                  errBox.textContent = "Não foi possível enviar (permissão do Firestore). Libere escrita autenticada na coleção b2b nas regras do Firestore.";
+                } else {
+                  errBox.textContent = "Não foi possível enviar agora. Tente novamente em instantes.";
+                }
+                errBox.style.display = "block";
+              }
+            }
+          });
+        }
       });
 
       window.addEventListener("load", () => {

--- a/styles.css
+++ b/styles.css
@@ -44096,9 +44096,9 @@ body.portal .request-toolbar {
 
 .nn-hero {
   width: min(100%, 1080px);
-  margin: 0 auto;
-  min-height: clamp(500px, 68vh, 700px);
-  padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 3vw, 3rem);
+  margin: clamp(2rem, 6vh, 3.5rem) auto 0;
+  min-height: clamp(520px, 70vh, 740px);
+  padding: clamp(2.75rem, 5vw, 4.25rem) clamp(1.5rem, 3vw, 3rem);
   text-align: center;
   font-family: 'Inter', sans-serif;
   background: rgba(129, 77, 104, 0.92);
@@ -44119,6 +44119,9 @@ body.portal .request-toolbar {
 
 .nn-hero__content {
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .nn-hero__badge {
@@ -44160,40 +44163,52 @@ body.portal .request-toolbar {
   font-size: 18px;
   line-height: 1.6;
   color: rgba(255, 244, 250, 0.94);
-  margin: 0 auto 48px;
+  margin: 0 auto 2.35rem;
   max-width: 520px;
+  text-align: center;
 }
 
 .nn-hero__ctas {
   display: flex;
-  justify-content: flex-start;
-  gap: 12px;
-  margin-bottom: 40px;
+  justify-content: center;
+  gap: 16px;
+  margin: 1.15rem 0 1.65rem;
+  width: 100%;
 }
 
 .nn-store {
-  background: #fff;
-  color: #814d68;
-  border: none;
-  padding: 12px 20px;
-  border-radius: 12px;
+  background: linear-gradient(180deg, #fff9fd 0%, #ffeef8 100%);
+  color: #6e3f59;
+  border: 1px solid rgba(255, 208, 230, 0.75);
+  padding: 16px 28px;
+  border-radius: 16px;
   font-family: 'Inter', sans-serif;
   text-decoration: none;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   text-align: left;
+  min-width: 220px;
+  box-shadow: 0 16px 30px -22px rgba(0, 0, 0, 0.5), 0 8px 16px -12px rgba(244, 92, 162, 0.55);
+  transition: transform 0.22s ease, box-shadow 0.22s ease, filter 0.22s ease;
+}
+
+.nn-store:hover,
+.nn-store:focus-visible {
+  transform: translateY(-2px);
+  filter: brightness(1.02);
+  box-shadow: 0 20px 34px -20px rgba(0, 0, 0, 0.5), 0 12px 22px -12px rgba(244, 92, 162, 0.6);
 }
 
 .nn-store__icon {
-  font-size: 18px;
+  font-size: 24px;
   line-height: 1;
 }
 
 .nn-store small {
   display: block;
-  font-size: 10px;
+  font-size: 11px;
   opacity: 0.8;
   font-weight: 400;
   line-height: 1;
@@ -44202,30 +44217,37 @@ body.portal .request-toolbar {
 
 .nn-store strong {
   display: block;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 18px;
+  font-weight: 600;
   line-height: 1.2;
 }
 
 .nn-hero__trust {
-  display: flex;
-  justify-content: flex-start;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: center;
-  gap: 32px;
-  font-size: 13px;
+  gap: 14px;
+  width: 100%;
+  margin-top: 1.35rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 227, 241, 0.26);
+  font-size: 14px;
   color: #fff;
-  flex-wrap: wrap;
 }
 
 .nn-hero__trust-item {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  justify-content: center;
+  text-align: center;
 }
 
 .nn-hero__image-wrap {
   display: flex;
   justify-content: center;
+  align-items: center;
+  transform: translateY(-10px);
 }
 
 .nn-hero__image {
@@ -44258,12 +44280,19 @@ body.portal .request-toolbar {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    margin: 1.1rem 0 1.35rem;
+  }
+
+  .nn-store {
+    min-width: min(100%, 280px);
+    justify-content: center;
   }
 
   .nn-hero__trust {
-    gap: 16px;
-    flex-direction: column;
-    justify-content: center;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    margin-top: 1rem;
+    padding-top: 0.85rem;
   }
 
   .nn-hero__layout {
@@ -44277,4 +44306,53 @@ body.portal .request-toolbar {
   .nn-hero__image {
     max-width: 300px;
   }
+}
+
+/* ===== NailNow B2B Form ===== */
+.nn-b2b-wrap {
+  background: #fff;
+  padding: 80px 28px;
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: 'Inter', sans-serif;
+}
+.nn-b2b-card {
+  background: #fff;
+  border: 1px solid #E5A8C7;
+  border-radius: 24px;
+  padding: 48px 44px;
+  max-width: 520px;
+  width: 100%;
+  box-shadow: 0 20px 60px -20px rgba(129, 77, 104, 0.15);
+  box-sizing: border-box;
+}
+.nn-b2b-eyebrow { display:inline-flex;align-items:center;gap:6px;background:#FFE3F1;color:#814D68;padding:6px 12px;border-radius:999px;font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:1px;margin-bottom:20px; }
+.nn-b2b-eyebrow .dot { width:6px;height:6px;border-radius:50%;background:#F45CA2; }
+.nn-b2b-title { font-family:'Playfair Display', Georgia, serif;font-size:36px;line-height:1.05;color:#814D68;margin:0 0 12px;font-weight:400;letter-spacing:-1px; }
+.nn-b2b-title em { color:#F45CA2;font-style:italic; }
+.nn-b2b-sub { font-size:15px;line-height:1.55;color:#814D68;margin:0 0 32px;opacity:.85; }
+.nn-field { margin-bottom:16px; }
+.nn-label { display:block;font-size:12px;font-weight:500;color:#814D68;margin-bottom:6px;letter-spacing:.3px; }
+.nn-input { width:100%;box-sizing:border-box;background:#fff;border:1px solid #E5A8C7;border-radius:12px;padding:14px 16px;font-family:'Inter', sans-serif;font-size:14px;color:#814D68;outline:none;transition:border-color .15s, box-shadow .15s; }
+.nn-input::placeholder { color:#C9A3B3; }
+.nn-input:focus { border-color:#F45CA2; box-shadow:0 0 0 3px rgba(244, 92, 162, .12); }
+.nn-input.is-error { border-color:#E04A92; box-shadow:0 0 0 3px rgba(224, 74, 146, .12); }
+.nn-row { display:grid;grid-template-columns:1fr 1fr;gap:12px; }
+.nn-cta-pill { width:100%;background:#F45CA2;color:#fff;border:none;padding:16px 36px;border-radius:999px;font-size:13px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;cursor:pointer;transition:background .2s, transform .05s, box-shadow .2s, opacity .2s;box-shadow:0 4px 12px -2px rgba(244, 92, 162, .35);margin-top:12px; }
+.nn-cta-pill:hover:not(:disabled) { background:#E04A92; box-shadow:0 6px 16px -2px rgba(244, 92, 162, .5); }
+.nn-cta-pill:active:not(:disabled) { transform:translateY(1px); box-shadow:0 2px 8px -2px rgba(244, 92, 162, .35); }
+.nn-cta-pill:disabled { opacity:.65; cursor:not-allowed; }
+.nn-spinner { display:inline-block;width:14px;height:14px;border:2px solid rgba(255,255,255,.4);border-top-color:#fff;border-radius:50%;animation:nn-spin .7s linear infinite;vertical-align:middle;margin-right:8px; }
+@keyframes nn-spin { to { transform: rotate(360deg); } }
+.nn-disclaimer { font-size:12px;color:#814D68;opacity:.7;text-align:center;margin:16px 0 0;line-height:1.5; }
+.nn-error-msg { background:#FFE3F1;color:#814D68;border:1px solid #E5A8C7;border-radius:10px;padding:10px 14px;font-size:13px;margin-top:12px;text-align:center; }
+.nn-success { text-align:center;padding:20px 0; }
+.nn-success-icon { width:56px;height:56px;border-radius:50%;background:#FFE3F1;color:#F45CA2;display:inline-flex;align-items:center;justify-content:center;font-size:28px;margin-bottom:16px; }
+@media (max-width: 540px) {
+  .nn-b2b-wrap { padding: 40px 16px; }
+  .nn-b2b-card { padding: 32px 24px; }
+  .nn-b2b-title { font-size: 28px; }
+  .nn-row { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation
- An eager anonymous auth call during professionals catalog load caused early failures (`auth/api-key-not-valid`) and interfered with the B2B submit UX, so auth should not be forced at page init and B2B writes must be resilient to Firestore rules.

### Description
- Removed the eager `ensureAnonymousAccess()` call from `ensureProfessionalsLoaded()` so the professionals catalog no longer forces anonymous login during page initialization. 
- Added a `saveB2BLead(payload)` helper that attempts `addDoc(collection(db, "b2b"), payload)` and only performs anonymous sign-in and retries when Firestore returns `permission-denied` to improve write reliability. 
- Inserted the B2B form HTML (`#nn-b2b-form`) above the Instagram feed and added corresponding styles under `.nn-b2b-*`, plus client-side masks/validations and a submit handler that calls `saveB2BLead` and renders success/error states. 
- Improved error messages surfaced to the user for `auth-failed` and `permission-denied` to make remediation clearer (enable anonymous auth or adjust Firestore rules). 

### Testing
- Ran static searches to confirm references and locations with `rg -n "ensureProfessionalsLoaded|ensureAnonymousAccess\(|collection\(db, \"b2b\"\)" index.html`, which located the updated code paths. 
- Reviewed diffs with `git diff -- index.html | sed -n '1,120p'` and the targeted region with `nl -ba index.html | sed -n '2316,2340p'`, which showed only the auth preflight removal and the new helper/form integration. 
- Verified the DOMContentLoaded wiring for the B2B form and the `saveB2BLead` retry logic via `nl -ba index.html | sed -n '3013,3225p'`; these static/smoke inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09000017848333aaf73ed851e49dec)