### PR TITLE
Configure Firestore rules for B2B lead submissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,5 +9,12 @@ service cloud.firestore {
       allow read: if true;
       allow update, delete: if false;
     }
+
+    match /b2b/{document} {
+      // Permite receber leads do formulário "Beleza como benefício corporativo".
+      allow create: if true;
+      // Bloqueia leitura/escrita adicional direto do cliente.
+      allow read, update, delete: if false;
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- The homepage B2B form writes to `collection(db, "b2b")` but Firestore rules did not include that path, causing `permission-denied` errors when submitting leads.

### Description
- Add a `match /b2b/{document}` rule that allows `create: if true` and denies `read, update, delete`, while preserving the existing `clientes` rules.

### Testing
- Committed the updated `firestore.rules` and created the PR via the internal tooling, and the CLI commands completed successfully; no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7701ec3c833398593a02b44f916d)