### PR TITLE
Add B2B Firestore rules and client-side B2B form validation, timeout, and improved error handling

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,5 +9,12 @@ service cloud.firestore {
       allow read: if true;
       allow update, delete: if false;
     }
+
+    match /b2b/{document} {
+      // Permite receber leads do formulário "Beleza como benefício corporativo".
+      allow create: if true;
+      // Bloqueia leitura/escrita adicional direto do cliente.
+      allow read, update, delete: if false;
+    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -1504,6 +1504,21 @@
       const app = initializeApp(firebaseConfig);
       const auth = getAuth(app);
       const db = getFirestore(app);
+
+      function validateFirebaseConfig(config = {}) {
+        const requiredFields = ["apiKey", "authDomain", "projectId"];
+        const missingFields = requiredFields.filter((field) => !config?.[field]);
+        if (missingFields.length) {
+          console.error("Firebase config incompleta:", missingFields.join(", "));
+          return false;
+        }
+        return true;
+      }
+
+      if (!validateFirebaseConfig(firebaseConfig)) {
+        console.error("Envio do formulário B2B pode falhar por configuração inválida do Firebase.");
+      }
+
       let authReadyPromise = null;
 
       const accentPalette = ["rose", "sunset", "violet", "ocean", "blush", "lavender"];
@@ -1600,9 +1615,18 @@
 
       async function saveB2BLead(payload) {
         const writeAttempt = async () => addDoc(collection(db, "b2b"), payload);
+        const withTimeout = (promise, timeoutMs = 15000) =>
+          Promise.race([
+            promise,
+            new Promise((_, reject) => {
+              const timeoutError = new Error("firestore-timeout");
+              timeoutError.code = "deadline-exceeded";
+              setTimeout(() => reject(timeoutError), timeoutMs);
+            }),
+          ]);
 
         try {
-          return await writeAttempt();
+          return await withTimeout(writeAttempt());
         } catch (error) {
           if (error?.code !== "permission-denied") {
             throw error;
@@ -1615,7 +1639,7 @@
             throw authError;
           }
 
-          return writeAttempt();
+          return withTimeout(writeAttempt());
         }
       }
 
@@ -3180,7 +3204,9 @@
                 if (message.startsWith("auth-failed:")) {
                   errBox.textContent = "Não foi possível autenticar no Firebase. Ative o login anônimo em Authentication > Sign-in method e tente novamente.";
                 } else if (code.includes("permission-denied")) {
-                  errBox.textContent = "Não foi possível enviar (permissão do Firestore). Libere escrita autenticada na coleção b2b nas regras do Firestore.";
+                  errBox.textContent = "Não foi possível enviar (permissão do Firestore). A coleção b2b precisa permitir create público.";
+                } else if (code.includes("deadline-exceeded") || code.includes("unavailable") || message.includes("503")) {
+                  errBox.textContent = "Instabilidade temporária no Firebase (503/conexão). Tente novamente em instantes.";
                 } else {
                   errBox.textContent = "Não foi possível enviar agora. Tente novamente em instantes.";
                 }


### PR DESCRIPTION
### Motivation
- Allow the public site to receive B2B leads while preventing arbitrary client-side reads/updates/deletes on that collection.
- Make the client-side B2B submission more robust by detecting invalid Firebase configuration early and surfacing transient/network problems.
- Provide clearer error messages to guide operators when permission or anonymous-auth issues occur.

### Description
- Added a new Firestore rule `match /b2b/{document}` that allows `create` and denies `read, update, delete` in `firestore.rules`.
- Added `validateFirebaseConfig` in `index.html` to verify required Firebase config fields (`apiKey`, `authDomain`, `projectId`) and log errors when incomplete.
- Implemented a `withTimeout` wrapper used by `saveB2BLead` to apply a 15s deadline to `addDoc` calls and changed retry behavior to reattempt the timed write after anonymous sign-in.
- Improved client-side error handling and user-facing messages to distinguish `permission-denied`, `auth-failed`, and timeout/unavailable/503 conditions.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7701ec3c833398593a02b44f916d)