### PR TITLE
Add B2B Firestore collection and improve client-side Firebase handling (config, timeout, errors)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,5 +9,12 @@ service cloud.firestore {
       allow read: if true;
       allow update, delete: if false;
     }
+
+    match /b2b/{document} {
+      // Permite receber leads do formulário "Beleza como benefício corporativo".
+      allow create: if true;
+      // Bloqueia leitura/escrita adicional direto do cliente.
+      allow read, update, delete: if false;
+    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -1492,18 +1492,33 @@
       } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
       const firebaseConfig = {
-        apiKey: "AIzaSyCFLccZ3khmT8uqoye6n6kfbqMFRzeXybE",
-        authDomain: "nailnow-7546c.firebaseapp.com",
-        projectId: "nailnow-7546c",
-        storageBucket: "nailnow-7546c.firebasestorage.app",
-        messagingSenderId: "413820353687",
-        appId: "1:413820353687:web:ad92108dbea59f7749fdd2",
-        measurementId: "G-2YEGPEG0E1",
+        apiKey: "AIzaSyBHVZ9M6btJemXCIG-g5dG0xWq_jy50H7o",
+        authDomain: "nailnow-site.firebaseapp.com",
+        projectId: "nailnow-site",
+        storageBucket: "nailnow-site.firebasestorage.app",
+        messagingSenderId: "726392294571",
+        appId: "1:726392294571:web:a363a40231f7ac162e7bee",
+        measurementId: "G-RTV9Y1PKKF",
       };
 
       const app = initializeApp(firebaseConfig);
       const auth = getAuth(app);
       const db = getFirestore(app);
+
+      function validateFirebaseConfig(config = {}) {
+        const requiredFields = ["apiKey", "authDomain", "projectId"];
+        const missingFields = requiredFields.filter((field) => !config?.[field]);
+        if (missingFields.length) {
+          console.error("Firebase config incompleta:", missingFields.join(", "));
+          return false;
+        }
+        return true;
+      }
+
+      if (!validateFirebaseConfig(firebaseConfig)) {
+        console.error("Envio do formulário B2B pode falhar por configuração inválida do Firebase.");
+      }
+
       let authReadyPromise = null;
 
       const accentPalette = ["rose", "sunset", "violet", "ocean", "blush", "lavender"];
@@ -1600,9 +1615,18 @@
 
       async function saveB2BLead(payload) {
         const writeAttempt = async () => addDoc(collection(db, "b2b"), payload);
+        const withTimeout = (promise, timeoutMs = 15000) =>
+          Promise.race([
+            promise,
+            new Promise((_, reject) => {
+              const timeoutError = new Error("firestore-timeout");
+              timeoutError.code = "deadline-exceeded";
+              setTimeout(() => reject(timeoutError), timeoutMs);
+            }),
+          ]);
 
         try {
-          return await writeAttempt();
+          return await withTimeout(writeAttempt());
         } catch (error) {
           if (error?.code !== "permission-denied") {
             throw error;
@@ -1615,7 +1639,7 @@
             throw authError;
           }
 
-          return writeAttempt();
+          return withTimeout(writeAttempt());
         }
       }
 
@@ -3180,7 +3204,9 @@
                 if (message.startsWith("auth-failed:")) {
                   errBox.textContent = "Não foi possível autenticar no Firebase. Ative o login anônimo em Authentication > Sign-in method e tente novamente.";
                 } else if (code.includes("permission-denied")) {
-                  errBox.textContent = "Não foi possível enviar (permissão do Firestore). Libere escrita autenticada na coleção b2b nas regras do Firestore.";
+                  errBox.textContent = "Não foi possível enviar (permissão do Firestore). A coleção b2b precisa permitir create público.";
+                } else if (code.includes("deadline-exceeded") || code.includes("unavailable") || message.includes("503")) {
+                  errBox.textContent = "Instabilidade temporária no Firebase (503/conexão). Tente novamente em instantes.";
                 } else {
                   errBox.textContent = "Não foi possível enviar agora. Tente novamente em instantes.";
                 }


### PR DESCRIPTION
### Motivation
- Permitir o recebimento de leads B2B no Firestore com regras dedicadas e migrar o site para o novo projeto Firebase;
- Tornar o envio do formulário B2B mais robusto contra configurações ausentes, autenticação anônima e instabilidades de rede.

### Description
- Adiciona a regra `match /b2b/{document}` em `firestore.rules` com `allow create: if true` e `allow read, update, delete: if false` para aceitar leads públicos sem leitura/escrita cliente adicional;
- Atualiza as credenciais do `firebaseConfig` em `index.html` para o novo projeto `nailnow-site` (novos valores de `apiKey`, `authDomain`, `projectId`, etc.);
- Introduz `validateFirebaseConfig` para checar campos obrigatórios do `firebaseConfig` e logar erro se incompleto;
- Adiciona o wrapper `withTimeout` (15s) e aplica ao `saveB2BLead` para evitar travamentos longos em escrita no Firestore, incluindo ao tentar o retry após `permission-denied` e preservando a autenticação anônima com `ensureAnonymousAccess` quando necessário;
- Melhora mensagens de erro de UI no envio B2B, diferenciando `permission-denied`, `deadline-exceeded`/`unavailable`/`503` e falhas genéricas para orientar ações apropriadas.

### Testing
- Nenhum teste automatizado foi adicionado ou executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7701ec3c833398593a02b44f916d)