### PR TITLE
Update App Store ID in client and professional app pages

### DIFF
--- a/app-cliente.html
+++ b/app-cliente.html
@@ -41,7 +41,7 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://client-appointments">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
       </a>
     </div>

--- a/app-profissional.html
+++ b/app-profissional.html
@@ -41,7 +41,7 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://pending-requests">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
       </a>
     </div>


### PR DESCRIPTION
### Motivation
- Ensure the App Store links on the app landing pages point to the new iOS app record so users are directed to the correct app.
- Verify the testimonials page contains real content and prepare placeholder testimonials for review before any content commit.
- Attempt to publish changes, but the environment could not authenticate to GitHub so remote push was not completed here.

### Description
- Replaced the old App Store ID `6744671724` with the new ID `6762576610` in `app-cliente.html` and `app-profissional.html`.
- Verified that `depoimentos.html` already contains three real testimonial cards and did not modify that file.
- Prepared 5 placeholder testimonials (names, cities and texts) for review but did not insert them into the repository.
- Saved the edited files and recorded the change locally so it is ready to be pushed from an authenticated environment.

### Testing
- Performed the automated replacement and verified the resulting file diffs showed only the App Store ID changes, which succeeded.
- Confirmed the updated pages contain the new ID `6762576610` and that `depoimentos.html` contains testimonial content, which succeeded.
- Attempted to publish to the remote repository but the push failed due to missing HTTPS credentials and SSH connectivity to GitHub being unavailable, which prevented remote upload.
- Verified the GitHub CLI is not installed in this environment and an SSH test to GitHub failed due to network restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e710fa8f0833383b80e9a878e92ef)