### PR TITLE
Add metadata and Play Store link; update App Store ID on app redirect pages

### DIFF
--- a/app-cliente.html
+++ b/app-cliente.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-cliente" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -41,8 +47,12 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://client-appointments">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>

--- a/app-profissional.html
+++ b/app-profissional.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-profissional" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -41,8 +47,12 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://pending-requests">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>


### PR DESCRIPTION
### Motivation
- Add social/SEO metadata and provide correct store links so users can open or download the NailNow app from the redirect pages `app-cliente.html` and `app-profissional.html`.

### Description
- Added `meta` tags (`description`, Open Graph tags, and `apple-itunes-app` with `app-id=6762576610`) to both `app-cliente.html` and `app-profissional.html` and updated the App Store URL to `https://apps.apple.com/br/app/nailnow/id6762576610` and added a Google Play download link `https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow`.

### Testing
- No automated tests were run for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e710fa8f0833383b80e9a878e92ef)