### PR TITLE
Add store fallbacks, metadata and Android download link to app deep-link pages

### DIFF
--- a/app-cliente.html
+++ b/app-cliente.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-cliente" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -41,21 +47,33 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://client-appointments">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a id="androidStoreBtn" class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>
       (function () {
         var deepLink = 'nailnow://client-appointments';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
+        var ua = navigator.userAgent || '';
+        var isAndroid = /Android/i.test(ua);
+        var fallbackUrl = isAndroid ? androidUrl : iosUrl;
         var start = Date.now();
+
         window.location = deepLink;
+
         setTimeout(function () {
           if (Date.now() - start < 2500) {
             document.getElementById('msg').textContent =
-              'Se o app não abriu, clique no botão abaixo para baixar.';
+              'Não conseguiu abrir o app? Redirecionando para a loja...';
+            window.location.href = fallbackUrl;
           }
-        }, 2000);
+        }, 1800);
       })();
     </script>
   </body>

--- a/app-profissional.html
+++ b/app-profissional.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-profissional" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -41,21 +47,33 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://pending-requests">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a id="androidStoreBtn" class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>
       (function () {
         var deepLink = 'nailnow://pending-requests';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
+        var ua = navigator.userAgent || '';
+        var isAndroid = /Android/i.test(ua);
+        var fallbackUrl = isAndroid ? androidUrl : iosUrl;
         var start = Date.now();
+
         window.location = deepLink;
+
         setTimeout(function () {
           if (Date.now() - start < 2500) {
             document.getElementById('msg').textContent =
-              'Se o app não abriu, clique no botão abaixo para baixar.';
+              'Não conseguiu abrir o app? Redirecionando para a loja...';
+            window.location.href = fallbackUrl;
           }
-        }, 2000);
+        }, 1800);
       })();
     </script>
   </body>


### PR DESCRIPTION
### Motivation
- Improve deep-linking UX by automatically redirecting users to the appropriate store when the native app fails to open. 
- Provide correct App Store metadata and Open Graph tags for better sharing and indexing of the launcher pages. 
- Add explicit Android Play Store support and update the App Store ID to the current app release.

### Description
- Updated `app-cliente.html` and `app-profissional.html` to add meta tags including `description`, Open Graph properties, `og:url`, and `apple-itunes-app` with the new App Store ID. 
- Replaced the old App Store link with `https://apps.apple.com/br/app/nailnow/id6762576610`, added an Android Play Store button linking to `https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow`, and added `id` attributes to store buttons. 
- Implemented JavaScript fallback logic that detects Android via `navigator.userAgent`, sets `fallbackUrl` accordingly, attempts the `deepLink`, and redirects to the store after a short timeout while updating the message; also adjusted the timeout from `2000`ms to `1800`ms.

### Testing
- Ran HTML validation and a link-check script against the modified pages, and both checks passed. 
- Performed a quick automated smoke check that confirmed the fallback redirect and updated links are present in the generated HTML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e710fa8f0833383b80e9a878e92ef)