### PR TITLE
Add App Store/Google Play links, OG/meta tags and Android fallback for deep links

### DIFF
--- a/app-cliente.html
+++ b/app-cliente.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-cliente" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -41,21 +47,33 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://client-appointments">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a id="androidStoreBtn" class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>
       (function () {
         var deepLink = 'nailnow://client-appointments';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
+        var ua = navigator.userAgent || '';
+        var isAndroid = /Android/i.test(ua);
+        var fallbackUrl = isAndroid ? androidUrl : iosUrl;
         var start = Date.now();
+
         window.location = deepLink;
+
         setTimeout(function () {
           if (Date.now() - start < 2500) {
             document.getElementById('msg').textContent =
-              'Se o app não abriu, clique no botão abaixo para baixar.';
+              'Não conseguiu abrir o app? Redirecionando para a loja...';
+            window.location.href = fallbackUrl;
           }
-        }, 2000);
+        }, 1800);
       })();
     </script>
   </body>

--- a/app-profissional.html
+++ b/app-profissional.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-profissional" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -41,21 +47,33 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://pending-requests">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a id="androidStoreBtn" class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>
       (function () {
         var deepLink = 'nailnow://pending-requests';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
+        var ua = navigator.userAgent || '';
+        var isAndroid = /Android/i.test(ua);
+        var fallbackUrl = isAndroid ? androidUrl : iosUrl;
         var start = Date.now();
+
         window.location = deepLink;
+
         setTimeout(function () {
           if (Date.now() - start < 2500) {
             document.getElementById('msg').textContent =
-              'Se o app não abriu, clique no botão abaixo para baixar.';
+              'Não conseguiu abrir o app? Redirecionando para a loja...';
+            window.location.href = fallbackUrl;
           }
-        }, 2000);
+        }, 1800);
       })();
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -1264,14 +1264,14 @@
                   </p>
 
                   <div class="nn-hero__ctas">
-                    <a class="nn-store" href="#" aria-label="Baixe na App Store">
+                    <a class="nn-store" href="https://apps.apple.com/br/app/nailnow/id6762576610" aria-label="Baixe na App Store" target="_blank" rel="noopener noreferrer">
                       <span class="nn-store__icon" aria-hidden="true"></span>
                       <span>
                         <small>Baixe na</small>
                         <strong>App Store</strong>
                       </span>
                     </a>
-                    <a class="nn-store" href="#" aria-label="Disponível no Google Play">
+                    <a class="nn-store" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow" aria-label="Disponível no Google Play" target="_blank" rel="noopener noreferrer">
                       <span class="nn-store__icon" aria-hidden="true">▶</span>
                       <span>
                         <small>Disponível no</small>


### PR DESCRIPTION
### Motivation
- Improve deep-link behavior by providing platform-specific store fallbacks when the app is not installed.
- Provide basic metadata and Open Graph tags for better sharing and app attribution via App Store.
- Expose correct App Store and Google Play destinations in the landing UI and hero CTAs.

### Description
- Added metadata (`meta` description, Open Graph tags and `apple-itunes-app`) to `app-cliente.html` and `app-profissional.html` and set the page `og:url` for each page.
- Updated the App Store ID/URL to `6762576610` and added Google Play URL `https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow` in `app-cliente.html`, `app-profissional.html`, and `index.html` with visible store buttons and IDs (`iosStoreBtn`, `androidStoreBtn`).
- Implemented UA-based fallback logic in the deep-linking script to choose between `iosUrl` and `androidUrl`, changed the user message and fallback redirect timing, and adjusted the timeout to `1800`ms.
- Updated the hero CTAs in `index.html` to point to the real store URLs and added `target="_blank" rel="noopener noreferrer"` to the external links.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e710fa8f0833383b80e9a878e92ef)