### PR TITLE
Add Meta Pixel, app store links and deep-link fallback to landing and app pages

### DIFF
--- a/app-cliente.html
+++ b/app-cliente.html
@@ -1,9 +1,29 @@
 <!doctype html>
 <html lang="pt-BR">
   <head>
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1351139600221663');
+      fbq('track', 'PageView');
+    </script>
+    <!-- End Meta Pixel Code -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-cliente" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -35,27 +55,48 @@
     </style>
   </head>
   <body>
+    <noscript>
+      <img
+        height="1"
+        width="1"
+        style="display:none"
+        src="https://www.facebook.com/tr?id=1351139600221663&ev=PageView&noscript=1"
+        alt=""
+      />
+    </noscript>
     <div class="card">
       <div class="logo">💅</div>
       <h1>Abrindo NailNow…</h1>
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://client-appointments">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a id="androidStoreBtn" class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>
       (function () {
         var deepLink = 'nailnow://client-appointments';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
+        var ua = navigator.userAgent || '';
+        var isAndroid = /Android/i.test(ua);
+        var fallbackUrl = isAndroid ? androidUrl : iosUrl;
         var start = Date.now();
+
         window.location = deepLink;
+
         setTimeout(function () {
           if (Date.now() - start < 2500) {
             document.getElementById('msg').textContent =
-              'Se o app não abriu, clique no botão abaixo para baixar.';
+              'Não conseguiu abrir o app? Redirecionando para a loja...';
+            window.location.href = fallbackUrl;
           }
-        }, 2000);
+        }, 1800);
       })();
     </script>
   </body>

--- a/app-profissional.html
+++ b/app-profissional.html
@@ -1,9 +1,29 @@
 <!doctype html>
 <html lang="pt-BR">
   <head>
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1351139600221663');
+      fbq('track', 'PageView');
+    </script>
+    <!-- End Meta Pixel Code -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:title" content="Abrindo NailNow" />
+    <meta property="og:description" content="Abra o app NailNow ou baixe na App Store e Google Play." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://nailnow.app/app-profissional" />
+    <meta name="apple-itunes-app" content="app-id=6762576610" />
     <title>Abrindo NailNow…</title>
     <style>
       * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -35,27 +55,48 @@
     </style>
   </head>
   <body>
+    <noscript>
+      <img
+        height="1"
+        width="1"
+        style="display:none"
+        src="https://www.facebook.com/tr?id=1351139600221663&ev=PageView&noscript=1"
+        alt=""
+      />
+    </noscript>
     <div class="card">
       <div class="logo">💅</div>
       <h1>Abrindo NailNow…</h1>
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://pending-requests">Abrir no app</a>
       <br/>
-      <a class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6744671724">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
         Baixar NailNow na App Store
+      </a>
+      <br/>
+      <a id="androidStoreBtn" class="btn-secondary" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow">
+        Baixar NailNow no Google Play
       </a>
     </div>
     <script>
       (function () {
         var deepLink = 'nailnow://pending-requests';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
+        var ua = navigator.userAgent || '';
+        var isAndroid = /Android/i.test(ua);
+        var fallbackUrl = isAndroid ? androidUrl : iosUrl;
         var start = Date.now();
+
         window.location = deepLink;
+
         setTimeout(function () {
           if (Date.now() - start < 2500) {
             document.getElementById('msg').textContent =
-              'Se o app não abriu, clique no botão abaixo para baixar.';
+              'Não conseguiu abrir o app? Redirecionando para a loja...';
+            window.location.href = fallbackUrl;
           }
-        }, 2000);
+        }, 1800);
       })();
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,20 @@
 <!doctype html>
 <html lang="pt-BR" class="no-js">
   <head>
+    <!-- Meta Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '1351139600221663');
+      fbq('track', 'PageView');
+    </script>
+    <!-- End Meta Pixel Code -->
     <script src="/assets/js/force-https.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -1165,6 +1179,15 @@
       </script>
   </head>
   <body>
+    <noscript>
+      <img
+        height="1"
+        width="1"
+        style="display:none"
+        src="https://www.facebook.com/tr?id=1351139600221663&ev=PageView&noscript=1"
+        alt=""
+      />
+    </noscript>
     <div class="promo-banner" role="region" aria-label="Convite para grupo do WhatsApp">
       <p class="promo-banner__message">
         💅 Manicures de Porto Alegre: entre no nosso grupo do WhatsApp para ficar por dentro do lançamento do app (maio 2026).
@@ -1264,14 +1287,14 @@
                   </p>
 
                   <div class="nn-hero__ctas">
-                    <a class="nn-store" href="#" aria-label="Baixe na App Store">
+                    <a class="nn-store" href="https://apps.apple.com/br/app/nailnow/id6762576610" aria-label="Baixe na App Store" target="_blank" rel="noopener noreferrer">
                       <span class="nn-store__icon" aria-hidden="true"></span>
                       <span>
                         <small>Baixe na</small>
                         <strong>App Store</strong>
                       </span>
                     </a>
-                    <a class="nn-store" href="#" aria-label="Disponível no Google Play">
+                    <a class="nn-store" href="https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow" aria-label="Disponível no Google Play" target="_blank" rel="noopener noreferrer">
                       <span class="nn-store__icon" aria-hidden="true">▶</span>
                       <span>
                         <small>Disponível no</small>


### PR DESCRIPTION
### Motivation
- Add client analytics and improve app install flow from the website and app redirect pages by installing Meta Pixel and providing clear store fallbacks. 
- Ensure deep links redirect users to the correct store when the native app cannot be opened. 

### Description
- Injected Meta Pixel tracking snippet into `index.html`, `app-cliente.html`, and `app-profissional.html` with a `noscript` fallback image. 
- Added store metadata and Open Graph tags to the app redirect pages and set `apple-itunes-app` meta to the updated App Store id `6762576610`. 
- Replaced placeholder store links with real App Store `https://apps.apple.com/br/app/nailnow/id6762576610` and Google Play `https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow` links across `index.html`, `app-cliente.html`, and `app-profissional.html`. 
- Implemented deep-link fallback logic in `app-cliente.html` and `app-profissional.html` that attempts `nailnow://...` then redirects to the platform-appropriate store (`iosUrl` / `androidUrl`) after a short timeout and updated the user-facing message. 

### Testing
- No automated tests were executed for these HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e710fa8f0833383b80e9a878e92ef)