### PR TITLE
Add Feedbacks page with Firestore-backed form and update header navigation

### DIFF
--- a/feedbacks.html
+++ b/feedbacks.html
@@ -20,26 +20,26 @@
       content="Leia relatos reais de clientes da NailNow sobre agendamentos com profissionais e experiências personalizadas."
     />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://www.nailnow.app/depoimentos" />
-    <link rel="alternate" hreflang="pt-BR" href="https://www.nailnow.app/depoimentos" />
+    <link rel="canonical" href="https://www.nailnow.app/feedbacks" />
+    <link rel="alternate" hreflang="pt-BR" href="https://www.nailnow.app/feedbacks" />
     <meta property="og:site_name" content="NailNow" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="pt_BR" />
-    <meta property="og:title" content="Depoimentos | NailNow" />
+    <meta property="og:title" content="Feedbacks | NailNow" />
     <meta
       property="og:description"
       content="Leia relatos reais de clientes da NailNow sobre agendamentos com profissionais e experiências personalizadas."
     />
-    <meta property="og:url" content="https://www.nailnow.app/depoimentos" />
+    <meta property="og:url" content="https://www.nailnow.app/feedbacks" />
     <meta property="og:image" content="https://www.nailnow.app/assets/nail1.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Depoimentos | NailNow" />
+    <meta name="twitter:title" content="Feedbacks | NailNow" />
     <meta
       name="twitter:description"
       content="Leia relatos reais de clientes da NailNow sobre agendamentos com profissionais e experiências personalizadas."
     />
     <meta name="twitter:image" content="https://www.nailnow.app/assets/nail1.png" />
-    <title>Depoimentos | NailNow</title>
+    <title>Feedbacks | NailNow</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -85,13 +85,15 @@
           {
             "@type": "ListItem",
             "position": 2,
-            "name": "Depoimentos",
-            "item": "https://www.nailnow.app/depoimentos"
+            "name": "Feedbacks",
+            "item": "https://www.nailnow.app/feedbacks"
           }
         ]
       }
     </script>
 <script src="/assets/js/menu-toggle.js" defer></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore-compat.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -169,45 +171,41 @@
 
     <main>
       <section class="page-hero">
-        <span class="eyebrow">Depoimentos</span>
-        <h1>Histórias reais de clientes NailNow</h1>
-        <p>Quem já agendou com a gente conta como é ter beleza profissional na hora certa.</p>
+        <span class="eyebrow">Feedbacks</span>
+        <h1>Envie seu feedback para a equipe NailNow</h1>
+        <p>Queremos ouvir você para evoluir nosso atendimento.</p>
       </section>
 
       <section class="testimonials">
         <div class="section-heading">
-          <h2>Experiências que inspiram confiança</h2>
-          <p>Selecionamos relatos completos para mostrar o impacto do atendimento personalizado.</p>
+          <h2>Compartilhe sua experiência</h2>
+          <p>Seu feedback ajuda a melhorar a experiência de clientes e profissionais na NailNow.</p>
         </div>
-        <div class="testimonials-grid">
-          <figure class="testimonial-card">
-            <blockquote>
-              "Nunca foi tão simples cuidar das minhas unhas. Agendei do trabalho e a profissional chegou pontualmente com todos os materiais higienizados."
-            </blockquote>
-            <figcaption>Renata • São Paulo</figcaption>
-          </figure>
-          <figure class="testimonial-card">
-            <blockquote>
-              "Adoro poder escolher por avaliações reais. As sugestões da NailNow acertam meu estilo toda vez!"
-            </blockquote>
-            <figcaption>Camila • Belo Horizonte</figcaption>
-          </figure>
-          <figure class="testimonial-card">
-            <blockquote>
-              "Usei para o dia do meu casamento e foi perfeito. Atendimento cuidadoso e retoques incluídos no pacote."
-            </blockquote>
-            <figcaption>Bianca • Campinas</figcaption>
-          </figure>
-        </div>
+        <form class="request-form" id="feedback-form">
+          <div class="request-form__group">
+            <label for="nome">Nome</label>
+            <input id="nome" name="nome" type="text" required />
+          </div>
+          <div class="request-form__group">
+            <label for="sobrenome">Sobrenome</label>
+            <input id="sobrenome" name="sobrenome" type="text" required />
+          </div>
+          <div class="request-form__group">
+            <label for="perfil">Você é:</label>
+            <select id="perfil" name="perfil" class="availability-form__input" required>
+              <option value="" selected disabled>Selecione uma opção</option>
+              <option value="profissional">Profissional</option>
+              <option value="cliente">Cliente</option>
+            </select>
+          </div>
+          <div class="request-form__group">
+            <label for="feedback">Seu feedback para a equipe NailNow</label>
+            <textarea id="feedback" name="feedback" rows="6" placeholder="Escreva aqui sua experiência, sugestões ou elogios." required></textarea>
+          </div>
+          <button type="submit" class="btn">Enviar feedback</button>
+        </form>
       </section>
 
-      <section class="page-highlight">
-        <div class="page-highlight__content">
-          <h2>Pronta para viver a experiência NailNow?</h2>
-          <p>Escolha sua profissional favorita, agende em poucos cliques e receba atendimento premium onde estiver.</p>
-        </div>
-        <a href="cliente" class="btn">Agendar atendimento</a>
-      </section>
     </main>
 
     <footer class="site-footer">
@@ -263,5 +261,46 @@
     </span>
     <span class="whatsapp-widget__text">WhatsApp</span>
   </a>
+  <script>
+    const firebaseConfig = {
+      apiKey: "AIzaSyBHVZ9M6btJemXCIG-g5dG0xWq_jy50H7o",
+      authDomain: "nailnow-site.firebaseapp.com",
+      projectId: "nailnow-site",
+      storageBucket: "nailnow-site.firebasestorage.app",
+      messagingSenderId: "726392294571",
+      appId: "1:726392294571:web:a363a40231f7ac162e7bee",
+      measurementId: "G-RTV9Y1PKKF",
+    };
+
+    firebase.initializeApp(firebaseConfig);
+    const db = firebase.firestore();
+
+    const feedbackForm = document.getElementById("feedback-form");
+
+    feedbackForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      const nome = feedbackForm.nome.value.trim();
+      const sobrenome = feedbackForm.sobrenome.value.trim();
+      const perfil = feedbackForm.perfil.value;
+      const feedback = feedbackForm.feedback.value.trim();
+
+      try {
+        await db.collection("feedback").add({
+          nome,
+          sobrenome,
+          perfil,
+          feedback,
+          criadoEm: new Date(),
+        });
+
+        alert("Feedback enviado com sucesso! Obrigada por contribuir com a NailNow.");
+        feedbackForm.reset();
+      } catch (error) {
+        console.error("Erro ao salvar feedback:", error);
+        alert("Não foi possível enviar seu feedback agora. Tente novamente em instantes.");
+      }
+    });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1226,6 +1226,7 @@
             <a href="/" class="nav-link" aria-current="page">Home</a>
             <a href="como-funciona" class="nav-link">Como funciona</a>
             <a href="servicos" class="nav-link">Serviços</a>
+            <a href="feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
             <a href="profissional" class="header-cta">Sou Manicure</a>


### PR DESCRIPTION
### Motivation
- Add a dedicated feedback submission page so customers and professionals can send experiences and suggestions to the team. 
- Make the new feedback page discoverable by adding a `Feedbacks` link to the site header navigation.

### Description
- Add `feedbacks.html` which includes SEO/meta tags, JSON-LD (Organization and Breadcrumb), Google Analytics, and site header/footer markup. 
- Implement a feedback form in `feedbacks.html` wired to Firebase/Firestore with an inline script that writes submissions to the `feedback` collection and shows success/error alerts. 
- Include a WhatsApp widget and social links on the new page, and load Firebase compatibility libraries used by the client script. 
- Update `index.html` and `depoimentos.html` to add a `Feedbacks` nav link in the primary navigation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb46ac6a08333af13e2cdefe04cf1)