### PR TITLE
Update iOS App Store links to new nailnow-app URL

### DIFF
--- a/app-cliente.html
+++ b/app-cliente.html
@@ -71,7 +71,7 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://client-appointments">Abrir no app</a>
       <br/>
-      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow-app/id6762576610">
         Baixar NailNow na App Store
       </a>
       <br/>
@@ -82,7 +82,7 @@
     <script>
       (function () {
         var deepLink = 'nailnow://client-appointments';
-        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow-app/id6762576610';
         var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
         var ua = navigator.userAgent || '';
         var isAndroid = /Android/i.test(ua);

--- a/app-profissional.html
+++ b/app-profissional.html
@@ -71,7 +71,7 @@
       <p id="msg">Aguarde, estamos abrindo o app para você.</p>
       <a id="openBtn" class="btn" href="nailnow://pending-requests">Abrir no app</a>
       <br/>
-      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow/id6762576610">
+      <a id="iosStoreBtn" class="btn-secondary" href="https://apps.apple.com/br/app/nailnow-app/id6762576610">
         Baixar NailNow na App Store
       </a>
       <br/>
@@ -82,7 +82,7 @@
     <script>
       (function () {
         var deepLink = 'nailnow://pending-requests';
-        var iosUrl = 'https://apps.apple.com/br/app/nailnow/id6762576610';
+        var iosUrl = 'https://apps.apple.com/br/app/nailnow-app/id6762576610';
         var androidUrl = 'https://play.google.com/store/apps/details?id=br.com.nailnow.nailnow';
         var ua = navigator.userAgent || '';
         var isAndroid = /Android/i.test(ua);

--- a/index.html
+++ b/index.html
@@ -1291,7 +1291,7 @@
                   </p>
 
                   <div class="nn-hero__ctas">
-                    <a class="nn-store" href="https://apps.apple.com/br/app/nailnow/id6762576610" aria-label="Baixe na App Store" target="_blank" rel="noopener noreferrer">
+                    <a class="nn-store" href="https://apps.apple.com/br/app/nailnow-app/id6762576610" aria-label="Baixe na App Store" target="_blank" rel="noopener noreferrer">
                       <span class="nn-store__icon" aria-hidden="true"></span>
                       <span>
                         <small>Baixe na</small>


### PR DESCRIPTION
### Motivation
- Ensure the site CTAs and deep-link fallbacks point to the correct App Store entry using the new `nailnow-app` slug provided.

### Description
- Replace `https://apps.apple.com/br/app/nailnow/id6762576610` with `https://apps.apple.com/br/app/nailnow-app/id6762576610` in `index.html`, `app-cliente.html`, and `app-profissional.html`.
- Update both anchor `href` values and the inline JS `iosUrl` fallback variables so deep-link fallbacks remain consistent across the three pages.
- No changes were made to Android links or other site behavior.

### Testing
- Verified occurrences and replacements via `rg -n "Baixe na|App Store|apps.apple"` before and after edits and confirmed the new URL is present in the three files.
- Ran the replacement script which reported updates for `index.html`, `app-cliente.html`, and `app-profissional.html`.
- Inspected the changes with `git diff -- index.html` and printed file excerpts with `nl -ba ...` to confirm the updated URLs.
- Attempted to capture a mobile screenshot with Playwright (`npx playwright screenshot ...`) but visual capture failed due to missing browser host dependencies in the environment despite running `npx playwright install`, so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fcf63749083339733067512c64f57)