### PR TITLE
Padroniza header em todas as páginas

### DIFF
--- a/agendamentos.html
+++ b/agendamentos.html
@@ -116,23 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/beneficio-corporativo.html
+++ b/beneficio-corporativo.html
@@ -50,7 +50,12 @@
           <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <button class="mobile-menu-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
           <span class="sr-only">Alternar menu</span>
           <span class="mobile-menu-toggle__bars" aria-hidden="true">
             <span class="mobile-menu-toggle__bar"></span>
@@ -61,13 +66,52 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
-            <a href="beneficio-corporativo" class="nav-link" aria-current="page">Benefício corporativo</a>
-            <a href="feedbacks" class="nav-link">Feedbacks</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
+            <a
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.linkedin.com/company/nailnowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.facebook.com/NailNowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/cliente/cadastro.html
+++ b/cliente/cadastro.html
@@ -94,6 +94,7 @@
     </script>
 
     <link rel="icon" type="image/svg+xml" href="/assets/nailnow-logo.svg" />
+    <script src="/assets/js/menu-toggle.js" defer></script>
   </head>
 
   <body>
@@ -104,27 +105,41 @@
           <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <div class="header-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
+          <span class="sr-only">Alternar menu</span>
+          <span class="mobile-menu-toggle__bars" aria-hidden="true">
+            <span class="mobile-menu-toggle__bar"></span>
+            <span class="mobile-menu-toggle__bar"></span>
+            <span class="mobile-menu-toggle__bar"></span>
+          </span>
+        </button>
+        <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="../como-funciona" class="nav-link">Como funciona</a>
-            <a href="../servicos" class="nav-link">Serviços</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="../profissional" class="header-cta">Sou Manicure</a>
-            <a href="../cliente" class="header-cta" aria-current="page">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/cliente/index.html
+++ b/cliente/index.html
@@ -157,24 +157,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="../como-funciona" class="nav-link">Como funciona</a>
-            <a href="../servicos" class="nav-link">Serviços</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="../profissional" class="header-cta">Sou Manicure</a>
-            <a href="../cliente" class="header-cta" aria-current="page">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/cliente/portal.html
+++ b/cliente/portal.html
@@ -115,25 +115,26 @@
         </button>
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
-            <a href="..//" class="nav-link">Home</a>
-            <a href="../como-funciona" class="nav-link">Como funciona</a>
-            <a href="../servicos" class="nav-link">Serviços</a>
+            <a href="/" class="nav-link">Home</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="../profissional" class="header-cta">Sou Manicure</a>
-            <a href="../cliente" class="header-cta" aria-current="page">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/como-funciona.html
+++ b/como-funciona.html
@@ -153,23 +153,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link" aria-current="page">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/confirmar-cadastro.html
+++ b/confirmar-cadastro.html
@@ -50,11 +50,16 @@
   <body>
     <header class="site-header">
       <div class="header-inner">
-        <a href="/index.html" class="brand-mark" aria-label="Início da NailNow">
-          <img src="/assets/nailnow-logo.svg" alt="" class="brand-mark__logo" />
+        <a href="/" class="brand-mark" aria-label="Início da NailNow">
+          <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <button class="mobile-menu-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
           <span class="sr-only">Alternar menu</span>
           <span class="mobile-menu-toggle__bars" aria-hidden="true">
             <span class="mobile-menu-toggle__bar"></span>
@@ -65,14 +70,16 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="/como-funciona.html" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="/cliente/index.html" class="header-cta">Sou Cliente</a>
-            <a href="/profissional/index.html" class="header-cta">Sou Profissional</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
               class="social-link social-link--instagram"
-              href="https://www.instagram.com/nailnowbr/"
+              href="https://www.instagram.com/nailnow/"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Instagram da NailNow"
@@ -80,6 +87,32 @@
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path
                   d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.linkedin.com/company/nailnowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.facebook.com/NailNowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
                 />
               </svg>
             </a>

--- a/conteudo.html
+++ b/conteudo.html
@@ -116,23 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/cookies-e-preferencias.html
+++ b/cookies-e-preferencias.html
@@ -67,23 +67,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/depoimentos.html
+++ b/depoimentos.html
@@ -116,24 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
-            <a href="feedbacks" class="nav-link">Feedbacks</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/excluir-conta.html
+++ b/excluir-conta.html
@@ -67,23 +67,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/faq.html
+++ b/faq.html
@@ -156,23 +156,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/feedbacks.html
+++ b/feedbacks.html
@@ -118,24 +118,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
-            <a href="feedbacks" class="nav-link">Feedbacks</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/index.html
+++ b/index.html
@@ -1225,26 +1225,26 @@
         </button>
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
-            <a href="/" class="nav-link" aria-current="page">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
-            <a href="beneficio-corporativo" class="nav-link">Benefício corporativo</a>
-            <a href="feedbacks" class="nav-link">Feedbacks</a>
+            <a href="/" class="nav-link">Home</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/manicure-a-domicilio-porto-alegre.html
+++ b/manicure-a-domicilio-porto-alegre.html
@@ -214,7 +214,12 @@
           <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <button class="mobile-menu-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
           <span class="sr-only">Alternar menu</span>
           <span class="mobile-menu-toggle__bars" aria-hidden="true">
             <span class="mobile-menu-toggle__bar"></span>
@@ -226,10 +231,51 @@
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
             <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
             <a href="/profissional" class="header-cta">Sou Manicure</a>
             <a href="/cliente" class="header-cta">Sou Cliente</a>
+            <a
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.linkedin.com/company/nailnowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.facebook.com/NailNowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/manicure-a-domicilio-rio-de-janeiro.html
+++ b/manicure-a-domicilio-rio-de-janeiro.html
@@ -214,7 +214,12 @@
           <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <button class="mobile-menu-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
           <span class="sr-only">Alternar menu</span>
           <span class="mobile-menu-toggle__bars" aria-hidden="true">
             <span class="mobile-menu-toggle__bar"></span>
@@ -226,10 +231,51 @@
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
             <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
             <a href="/profissional" class="header-cta">Sou Manicure</a>
             <a href="/cliente" class="header-cta">Sou Cliente</a>
+            <a
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.linkedin.com/company/nailnowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.facebook.com/NailNowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/manicure-a-domicilio-sao-paulo.html
+++ b/manicure-a-domicilio-sao-paulo.html
@@ -214,7 +214,12 @@
           <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <button class="mobile-menu-toggle" type="button" aria-expanded="false" aria-controls="site-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
           <span class="sr-only">Alternar menu</span>
           <span class="mobile-menu-toggle__bars" aria-hidden="true">
             <span class="mobile-menu-toggle__bar"></span>
@@ -226,10 +231,51 @@
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
             <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
             <a href="/profissional" class="header-cta">Sou Manicure</a>
             <a href="/cliente" class="header-cta">Sou Cliente</a>
+            <a
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.linkedin.com/company/nailnowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.facebook.com/NailNowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
+                />
+              </svg>
+            </a>
           </div>
         </div>
       </div>

--- a/manicures.html
+++ b/manicures.html
@@ -116,23 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/politica-de-privacidade.html
+++ b/politica-de-privacidade.html
@@ -67,23 +67,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/profissional.html
+++ b/profissional.html
@@ -370,11 +370,13 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="../como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="../profissional" class="header-cta" aria-current="page">Sou Manicure</a>
-            <a href="../cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
               class="social-link social-link--instagram"
               href="https://www.instagram.com/nailnow/"

--- a/profissional/cadastro.html
+++ b/profissional/cadastro.html
@@ -515,28 +515,43 @@
       });
     </script>
     <link rel="icon" type="image/svg+xml" href="/assets/nailnow-logo.svg" />
+    <script src="/assets/js/menu-toggle.js" defer></script>
   </head>
 
   <body>
 
     <header class="site-header">
       <div class="header-inner">
-        <a href="/index.html" class="brand-mark" aria-label="Início da NailNow">
-          <img src="/assets/nailnow-logo.svg" alt="" class="brand-mark__logo" />
+        <a href="/" class="brand-mark" aria-label="Início da NailNow">
+          <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
           <span class="brand-mark__text">NailNow</span>
         </a>
-        <div class="header-navigation">
+        <button
+          class="mobile-menu-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-navigation"
+        >
+          <span class="sr-only">Alternar menu</span>
+          <span class="mobile-menu-toggle__bars" aria-hidden="true">
+            <span class="mobile-menu-toggle__bar"></span>
+            <span class="mobile-menu-toggle__bar"></span>
+            <span class="mobile-menu-toggle__bar"></span>
+          </span>
+        </button>
+        <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="../como-funciona.html" class="nav-link">Como funciona</a>
-            <a href="../servicos.html" class="nav-link">Serviços</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="../cliente/index.html" class="header-cta">Sou Cliente</a>
-            <a href="../profissional/index.html" class="header-cta" aria-current="page">Sou Profissional</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
               class="social-link social-link--instagram"
-              href="https://www.instagram.com/nailnowbr/"
+              href="https://www.instagram.com/nailnow/"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Instagram da NailNow"
@@ -544,6 +559,32 @@
               <svg viewBox="0 0 24 24" aria-hidden="true">
                 <path
                   d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.linkedin.com/company/nailnowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="social-link"
+              href="https://www.facebook.com/NailNowapp/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Facebook da NailNow"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
                 />
               </svg>
             </a>

--- a/profissional/login.html
+++ b/profissional/login.html
@@ -185,7 +185,10 @@
 
     <header class="site-header">
       <div class="header-inner">
-        <a href="/" class="brand-mark" aria-label="Início da NailNow">NailNow</a>
+        <a href="/" class="brand-mark" aria-label="Início da NailNow">
+          <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
+          <span class="brand-mark__text">NailNow</span>
+        </a>
         <button
           class="mobile-menu-toggle"
           type="button"
@@ -202,25 +205,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="../como-funciona" class="nav-link">Como funciona</a>
-            <a href="../servicos" class="nav-link">Serviços</a>
-            <a href="../agendamentos" class="nav-link">Agendamentos</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="/profissional" class="header-cta" aria-current="page">Sou Manicure</a>
-            <a href="../cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/profissional/portal.html
+++ b/profissional/portal.html
@@ -115,25 +115,26 @@
         </button>
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
-            <a href="..//" class="nav-link">Home</a>
-            <a href="../como-funciona" class="nav-link">Como funciona</a>
-            <a href="../servicos" class="nav-link">Serviços</a>
+            <a href="/" class="nav-link">Home</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="../profissional" class="header-cta">Sou Manicure</a>
-            <a href="../cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/quem-somos.html
+++ b/quem-somos.html
@@ -116,23 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/servicos.html
+++ b/servicos.html
@@ -1199,23 +1199,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/servicos/index.html
+++ b/servicos/index.html
@@ -268,24 +268,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
-            <a href="servicos" class="nav-link" aria-current="page">Serviços</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/styles.css
+++ b/styles.css
@@ -39310,13 +39310,6 @@ main {
   justify-self: end;
 }
 
-.header-actions .social-link {
-  margin-left: auto;
-}
-
-.header-actions .social-link {
-  margin-left: auto;
-}
 
 .brand-mark {
   display: inline-flex;
@@ -39348,7 +39341,7 @@ main {
   display: flex;
   align-items: center;
   gap: clamp(1rem, 3vw, 2rem);
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: flex-start;
   grid-column: 1;
   justify-self: start;
@@ -39414,6 +39407,7 @@ main {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding-bottom: 0.35rem;
+  white-space: nowrap;
   transition: color 0.3s ease;
 }
 

--- a/termos-cliente.html
+++ b/termos-cliente.html
@@ -116,23 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/termos-de-uso.html
+++ b/termos-de-uso.html
@@ -67,23 +67,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"

--- a/termos-manicure.html
+++ b/termos-manicure.html
@@ -116,23 +116,25 @@
         <div class="header-navigation" id="site-navigation">
           <nav class="primary-nav" aria-label="Principal">
             <a href="/" class="nav-link">Home</a>
-            <a href="como-funciona" class="nav-link">Como funciona</a>
+            <a href="/como-funciona" class="nav-link">Como funciona</a>
+            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
+            <a href="/feedbacks" class="nav-link">Feedbacks</a>
           </nav>
           <div class="header-actions">
-            <a href="profissional" class="header-cta">Sou Manicure</a>
-            <a href="cliente" class="header-cta">Sou Cliente</a>
+            <a href="/profissional" class="header-cta">Sou Manicure</a>
+            <a href="/cliente" class="header-cta">Sou Cliente</a>
             <a
-            class="social-link social-link--instagram"
-            href="https://www.instagram.com/nailnow/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Instagram da NailNow"
+              class="social-link social-link--instagram"
+              href="https://www.instagram.com/nailnow/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram da NailNow"
             >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-            d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-            />
-            </svg>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                />
+              </svg>
             </a>
             <a
               class="social-link"


### PR DESCRIPTION
### Motivation
- Unificar o header em todas as páginas para garantir consistência visual e de navegação (mesmos links, CTAs e ícones sociais). 
- Evitar quebra de linha nas abas do menu no desktop para manter itens como “Benefício corporativo” em uma única linha. 

### Description
- Substituído o `<header class="site-header">...</header>` por uma versão padrão em 29 arquivos HTML, com links para `Home`, `Como funciona`, `Benefício corporativo`, `Feedbacks`, CTAs `Sou Manicure` / `Sou Cliente` e ícones sociais (Instagram / LinkedIn / Facebook). 
- Normalizados os caminhos de navegação para rotas absolutas (`/como-funciona`, `/beneficio-corporativo`, `/feedbacks`, `/profissional`, `/cliente`) para funcionarem também em subdiretórios. 
- Adicionado o botão de menu móvel (`.mobile-menu-toggle`) e garantido o carregamento do script `assets/js/menu-toggle.js` em páginas que não o tinham (ex.: `cliente/cadastro.html`, `profissional/cadastro.html`). 
- Ajustes de CSS em `styles.css`: removida duplicação de regra, `primary-nav` usa `flex-wrap: nowrap` e `.nav-link` recebeu `white-space: nowrap` para evitar quebras de linha nas abas. 

### Testing
- Executado `git diff --check` para validar alterações de formatação e conflitos; passou sem erros. 
- Rodado um script Python que verificou que existem `29 headers` e que todos usam a mesma versão única do header (`29 headers, 1 unique`), confirmação bem-sucedida. 
- Tentativa de capturar screenshot com `npx playwright screenshot --viewport-size=2048,420 http://127.0.0.1:8000/ header-screenshot.png` falhou por falta de dependência do ambiente (`libatk-1.0.so.0`), portanto a verificação visual automática não pôde ser concluída no CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38021fd0908333be3f864942e146de)