### PR TITLE
Padroniza footer do beneficio-corporativo com o da home

### DIFF
--- a/beneficio-corporativo.html
+++ b/beneficio-corporativo.html
@@ -171,23 +171,31 @@
     </main>
 
     <footer class="site-footer">
-      <div class="footer-grid">
-        <div class="footer-brand">
-          <a href="/" class="brand-mark" aria-label="Início da NailNow">
-            <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
-            <span class="brand-mark__text">NailNow</span>
-          </a>
-          <p>Manicure e pedicure a domicílio com profissionais verificadas.</p>
+      <div class="footer-inner">
+        <div class="footer-column footer-column--brand">
+          <h2 class="footer-logo">NailNow</h2>
+          <p>Beleza na sua agenda com profissionais selecionadas, atendimento onde você estiver e suporte humanizado.</p>
+        </div>
+        <div class="footer-column footer-links" aria-label="Links úteis">
+          <h3>FAQ</h3>
+          <a href="faq">Perguntas frequentes</a>
+          <a href="como-funciona">Como funciona</a>
+          <a href="agendamentos">Agendamentos</a>
+        </div>
+        <div class="footer-column footer-links" aria-label="Contato e suporte">
+          <h3>Contato & suporte</h3>
+          <a href="mailto:suporte@nailnow.app">suporte@nailnow.app</a>
         </div>
         <div class="footer-column footer-links" aria-label="Institucional">
-          <h2>Institucional</h2>
+          <h3>Institucional</h3>
           <a href="/quem-somos">Quem somos</a>
-          <a href="/beneficio-corporativo">Benefício corporativo</a>
         </div>
         <div class="footer-column footer-links" aria-label="Termos e políticas">
-          <h2>Termos & políticas</h2>
+          <h3>Termos & políticas</h3>
           <a href="/termos-de-uso">Termos de uso</a>
           <a href="/politica-de-privacidade">Política de privacidade</a>
+          <a href="/excluir-conta">Exclusão de conta e dados</a>
+          <a href="/cookies-e-preferencias">Cookies e preferências</a>
         </div>
       </div>
       <p class="footer-copy">© NailNow 2026. Todos os direitos reservados. NAILNOW SERVICOS DIGITAIS LTDA</p>


### PR DESCRIPTION
## Summary
- Substitui o footer reduzido (`footer-grid`/`footer-brand`) da página `beneficio-corporativo` pelo footer completo da home (`footer-inner`/`footer-column`).
- Mantém as mesmas seções: brand, FAQ, Contato & suporte, Institucional, Termos & políticas.

## Test plan
- [ ] Visitar `https://nailnow.app/beneficio-corporativo` após deploy e conferir que o footer ficou idêntico ao da home.
- [ ] Conferir links: FAQ, suporte@nailnow.app, exclusão de conta, cookies — todos clicáveis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)