### PR TITLE
Home: header no estilo do standalone (nn-topbar)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1208,7 +1208,7 @@
       /* Topbar isolada da home — não afeta outras páginas */
       .nn-topbar{--nn-tb-pink:#F45CA2;--nn-tb-pink-strong:#FE68BF;--nn-tb-mauve:#814D68;--nn-tb-line:#E5A8C7;--nn-tb-ink:#1d1320;--nn-tb-ink-soft:#5b4a55;background:#fff;border-bottom:1px solid rgba(229,168,199,.45);position:sticky;top:0;z-index:50;font-family:'Poppins','Inter',system-ui,sans-serif}
       .nn-topbar *{box-sizing:border-box}
-      .nn-topbar .nn-tb-wrap{max-width:1160px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:20px;height:72px}
+      .nn-topbar .nn-tb-wrap{max-width:1320px;margin:0 auto;padding:0 32px;display:flex;align-items:center;gap:20px;height:80px}
       .nn-topbar .nn-tb-brand{display:flex;align-items:center;gap:9px;font-family:'Playfair Display',serif;font-weight:700;font-size:1.3rem;color:var(--nn-tb-ink);flex-shrink:0;text-decoration:none}
       .nn-topbar .nn-tb-brand img{width:30px;height:30px;flex-shrink:0;display:block}
       .nn-topbar .nn-tb-nav{display:flex;align-items:center;gap:20px;font-size:.88rem;font-weight:500;margin-right:auto;margin-left:6px}
@@ -1308,7 +1308,7 @@
         .nn-home *{box-sizing:border-box;margin:0;padding:0}
         .nn-home a{text-decoration:none;color:inherit}
         .nn-home img,.nn-home svg{display:block;max-width:100%}
-        .nn-home .nn-wrap{max-width:1160px;margin:0 auto;padding:0 24px;width:100%}
+        .nn-home .nn-wrap{max-width:1320px;margin:0 auto;padding:0 32px;width:100%}
 
         /* hero — reset agressivo pra neutralizar .nn-hero global do styles.css */
         .nn-home .nn-hero{
@@ -1328,9 +1328,9 @@
         .nn-home .nn-hero .nn-wrap{position:relative;z-index:2;display:grid;grid-template-columns:1.05fr .95fr;gap:56px;align-items:center;padding:68px 24px 80px}
         .nn-home .nn-eyebrow{display:inline-flex;align-items:center;gap:8px;background:#fff;border:1px solid var(--nn-line);color:var(--nn-mauve);font-weight:600;font-size:.82rem;padding:7px 15px;border-radius:999px;margin-bottom:24px;box-shadow:0 6px 18px -12px rgba(129,77,104,.5)}
         .nn-home .nn-dot{width:8px;height:8px;border-radius:50%;background:var(--nn-pink-strong);box-shadow:0 0 0 4px rgba(254,104,191,.22)}
-        .nn-home .nn-headline{font-family:'Poppins',sans-serif;font-weight:600;font-size:clamp(2.3rem,4.6vw,3.5rem);line-height:1.08;letter-spacing:-.01em;color:var(--nn-ink);margin-bottom:20px}
+        .nn-home .nn-headline{font-family:'Poppins',sans-serif;font-weight:600;font-size:clamp(2.6rem,5.4vw,4.4rem);line-height:1.08;letter-spacing:-.01em;color:var(--nn-ink);margin-bottom:24px}
         .nn-home .nn-headline .nn-serif{font-family:'Playfair Display',serif;font-style:italic;font-weight:600;color:var(--nn-pink)}
-        .nn-home .nn-sub{font-size:clamp(1rem,1.4vw,1.12rem);color:var(--nn-ink-soft);max-width:32ch;margin-bottom:32px}
+        .nn-home .nn-sub{font-size:clamp(1.05rem,1.5vw,1.25rem);color:var(--nn-ink-soft);max-width:36ch;margin-bottom:36px}
         .nn-home .nn-cta-row{display:flex;flex-wrap:wrap;gap:14px;align-items:center;margin-bottom:18px}
         .nn-home .nn-btn{display:inline-flex;align-items:center;justify-content:center;gap:10px;font-family:'Poppins',sans-serif;font-weight:600;font-size:1rem;padding:15px 26px;border-radius:var(--nn-radius);cursor:pointer;border:1.6px solid transparent;transition:transform .15s ease,box-shadow .15s ease,background .15s ease}
         .nn-home .nn-btn-primary{background:var(--nn-pink);color:#fff;box-shadow:var(--nn-shadow)}
@@ -1357,7 +1357,7 @@
         .nn-home .nn-how{padding:74px 0 30px;background:#fff;width:100%}
         .nn-home .nn-section-head{text-align:center;max-width:640px;margin:0 auto 48px}
         .nn-home .nn-section-head .nn-tag{color:var(--nn-pink);font-weight:600;font-size:.8rem;letter-spacing:.14em;text-transform:uppercase}
-        .nn-home .nn-section-head h2{font-family:'Playfair Display',serif;font-weight:600;font-size:clamp(1.8rem,3.2vw,2.4rem);margin-top:10px;color:var(--nn-ink);line-height:1.15}
+        .nn-home .nn-section-head h2{font-family:'Playfair Display',serif;font-weight:600;font-size:clamp(2rem,3.6vw,2.9rem);margin-top:10px;color:var(--nn-ink);line-height:1.15}
         .nn-home .nn-steps{display:grid;grid-template-columns:repeat(3,1fr);gap:22px}
         .nn-home .nn-step{background:var(--nn-bg);border-radius:var(--nn-radius);padding:30px 26px;border:1px solid rgba(229,168,199,.4)}
         .nn-home .nn-step .nn-n{font-family:'Playfair Display',serif;font-style:italic;font-weight:600;font-size:2.1rem;color:var(--nn-pink-soft);line-height:1;margin-bottom:14px}

--- a/index.html
+++ b/index.html
@@ -1204,78 +1204,89 @@
         Entrar no WhatsApp
       </a>
     </div>
-    <header class="site-header">
-      <div class="header-inner">
-        <a href="/" class="brand-mark" aria-label="Início da NailNow">
-          <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" class="brand-mark__logo" />
-          <span class="brand-mark__text">NailNow</span>
+    <style>
+      /* Topbar isolada da home — não afeta outras páginas */
+      .nn-topbar{--nn-tb-pink:#F45CA2;--nn-tb-pink-strong:#FE68BF;--nn-tb-mauve:#814D68;--nn-tb-line:#E5A8C7;--nn-tb-ink:#1d1320;--nn-tb-ink-soft:#5b4a55;background:#fff;border-bottom:1px solid rgba(229,168,199,.45);position:sticky;top:0;z-index:50;font-family:'Poppins','Inter',system-ui,sans-serif}
+      .nn-topbar *{box-sizing:border-box}
+      .nn-topbar .nn-tb-wrap{max-width:1160px;margin:0 auto;padding:0 24px;display:flex;align-items:center;gap:20px;height:72px}
+      .nn-topbar .nn-tb-brand{display:flex;align-items:center;gap:9px;font-family:'Playfair Display',serif;font-weight:700;font-size:1.3rem;color:var(--nn-tb-ink);flex-shrink:0;text-decoration:none}
+      .nn-topbar .nn-tb-brand img{width:30px;height:30px;flex-shrink:0;display:block}
+      .nn-topbar .nn-tb-nav{display:flex;align-items:center;gap:20px;font-size:.88rem;font-weight:500;margin-right:auto;margin-left:6px}
+      .nn-topbar .nn-tb-nav a{color:var(--nn-tb-ink-soft);white-space:nowrap;text-decoration:none;transition:color .15s ease}
+      .nn-topbar .nn-tb-nav a:hover{color:var(--nn-tb-pink)}
+      .nn-topbar .nn-tb-actions{display:flex;align-items:center;gap:11px;flex-shrink:0}
+      .nn-topbar .nn-tb-btn{font-size:.84rem;font-weight:600;padding:9px 15px;border-radius:12px;white-space:nowrap;transition:border-color .15s ease,color .15s ease,background .15s ease;text-decoration:none;display:inline-block;line-height:1.2}
+      .nn-topbar .nn-tb-btn.is-ghost{color:var(--nn-tb-mauve);border:1.4px solid var(--nn-tb-line);background:#fff}
+      .nn-topbar .nn-tb-btn.is-ghost:hover{border-color:var(--nn-tb-pink);color:var(--nn-tb-pink)}
+      .nn-topbar .nn-tb-btn.is-solid{background:var(--nn-tb-pink);color:#fff;border:1.4px solid var(--nn-tb-pink)}
+      .nn-topbar .nn-tb-btn.is-solid:hover{background:var(--nn-tb-pink-strong);border-color:var(--nn-tb-pink-strong)}
+      .nn-topbar .nn-tb-socials{display:flex;align-items:center;gap:11px;padding-left:13px;border-left:1px solid var(--nn-tb-line)}
+      .nn-topbar .nn-tb-socials a{color:var(--nn-tb-mauve);display:flex;transition:color .15s ease}
+      .nn-topbar .nn-tb-socials a:hover{color:var(--nn-tb-pink)}
+      .nn-topbar .nn-tb-socials svg{width:18px;height:18px}
+      .nn-topbar .nn-tb-toggle{display:none;background:none;border:0;cursor:pointer;font-size:1.5rem;line-height:1;color:var(--nn-tb-mauve);margin-left:auto;padding:6px 10px}
+      .nn-topbar .nn-tb-mobile{display:none;flex-direction:column;gap:4px;padding:14px 24px 20px;border-bottom:1px solid rgba(229,168,199,.45);background:#fff}
+      .nn-topbar .nn-tb-mobile a.nn-tb-m-link{padding:11px 4px;font-weight:500;color:var(--nn-tb-ink);border-bottom:1px solid rgba(229,168,199,.3);text-decoration:none}
+      .nn-topbar .nn-tb-mobile .nn-tb-m-actions{display:flex;gap:10px;margin-top:12px}
+      .nn-topbar .nn-tb-mobile .nn-tb-m-actions .nn-tb-btn{flex:1;text-align:center}
+      .nn-topbar .nn-tb-mobile:not([hidden]){display:flex}
+      @media (max-width:1180px){ .nn-topbar .nn-tb-socials{display:none} }
+      @media (max-width:1080px){
+        .nn-topbar .nn-tb-nav,.nn-topbar .nn-tb-actions{display:none}
+        .nn-topbar .nn-tb-toggle{display:block}
+      }
+    </style>
+    <header class="nn-topbar">
+      <div class="nn-tb-wrap">
+        <a class="nn-tb-brand" href="/" aria-label="Início da NailNow">
+          <img src="/assets/nailnow-logo.svg" alt="Logotipo da NailNow" />
+          NailNow
         </a>
-        <button
-          class="mobile-menu-toggle"
-          type="button"
-          aria-expanded="false"
-          aria-controls="site-navigation"
-        >
-          <span class="sr-only">Alternar menu</span>
-          <span class="mobile-menu-toggle__bars" aria-hidden="true">
-            <span class="mobile-menu-toggle__bar"></span>
-            <span class="mobile-menu-toggle__bar"></span>
-            <span class="mobile-menu-toggle__bar"></span>
-          </span>
-        </button>
-        <div class="header-navigation" id="site-navigation">
-          <nav class="primary-nav" aria-label="Principal">
-            <a href="/" class="nav-link">Home</a>
-            <a href="/como-funciona" class="nav-link">Como funciona</a>
-            <a href="/beneficio-corporativo" class="nav-link">Benefício corporativo</a>
-            <a href="/feedbacks" class="nav-link">Feedbacks</a>
-          </nav>
-          <div class="header-actions">
-            <a href="/profissional" class="header-cta">Sou Manicure</a>
-            <a href="/cliente" class="header-cta">Sou Cliente</a>
-            <a
-              class="social-link social-link--instagram"
-              href="https://www.instagram.com/nailnow/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Instagram da NailNow"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M7 3C4.24 3 2 5.24 2 8v8c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V8c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V8a3 3 0 0 1 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 13 4.5 4.5 0 0 0 12 8.5zm0 2A2.5 2.5 0 1 1 9.5 13 2.5 2.5 0 0 1 12 10.5zm4.75-4.75a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
-                />
-              </svg>
+        <nav class="nn-tb-nav" aria-label="Principal">
+          <a href="/">Home</a>
+          <a href="/como-funciona">Como funciona</a>
+          <a href="/beneficio-corporativo">Benefício corporativo</a>
+          <a href="/feedbacks">Feedbacks</a>
+        </nav>
+        <div class="nn-tb-actions">
+          <a class="nn-tb-btn is-ghost" href="/profissional">Sou Manicure</a>
+          <a class="nn-tb-btn is-solid" href="/cliente">Sou Cliente</a>
+          <div class="nn-tb-socials">
+            <a href="https://www.instagram.com/nailnow/" target="_blank" rel="noopener noreferrer" aria-label="Instagram da NailNow">
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.16c3.2 0 3.58.01 4.85.07 1.17.05 1.8.25 2.23.41.56.22.96.48 1.38.9.42.42.68.82.9 1.38.16.42.36 1.06.41 2.23.06 1.27.07 1.65.07 4.85s-.01 3.58-.07 4.85c-.05 1.17-.25 1.8-.41 2.23-.22.56-.48.96-.9 1.38-.42.42-.82.68-1.38.9-.42.16-1.06.36-2.23.41-1.27.06-1.65.07-4.85.07s-3.58-.01-4.85-.07c-1.17-.05-1.8-.25-2.23-.41a3.7 3.7 0 01-1.38-.9 3.7 3.7 0 01-.9-1.38c-.16-.42-.36-1.06-.41-2.23C2.17 15.58 2.16 15.2 2.16 12s.01-3.58.07-4.85c.05-1.17.25-1.8.41-2.23.22-.56.48-.96.9-1.38.42-.42.82-.68 1.38-.9.42-.16 1.06-.36 2.23-.41C8.42 2.17 8.8 2.16 12 2.16zm0 1.62c-3.15 0-3.5.01-4.74.07-1.14.05-1.76.24-2.17.4-.55.21-.94.47-1.35.88-.41.41-.67.8-.88 1.35-.16.41-.35 1.03-.4 2.17-.06 1.24-.07 1.59-.07 4.74s.01 3.5.07 4.74c.05 1.14.24 1.76.4 2.17.21.55.47.94.88 1.35.41.41.8.67 1.35.88.41.16 1.03.35 2.17.4 1.24.06 1.59.07 4.74.07s3.5-.01 4.74-.07c1.14-.05 1.76-.24 2.17-.4.55-.21.94-.47 1.35-.88.41-.41.67-.8.88-1.35.16-.41.35-1.03.4-2.17.06-1.24.07-1.59.07-4.74s-.01-3.5-.07-4.74c-.05-1.14-.24-1.76-.4-2.17a3.6 3.6 0 00-.88-1.35 3.6 3.6 0 00-1.35-.88c-.41-.16-1.03-.35-2.17-.4-1.24-.06-1.59-.07-4.74-.07zm0 2.76a5.46 5.46 0 110 10.92 5.46 5.46 0 010-10.92zm0 9a3.54 3.54 0 100-7.08 3.54 3.54 0 000 7.08zm6.95-9.22a1.27 1.27 0 11-2.55 0 1.27 1.27 0 012.55 0z"/></svg>
             </a>
-            <a
-              class="social-link"
-              href="https://www.linkedin.com/company/nailnowapp/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn da NailNow"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M6.94 8.5H3.56V20h3.38V8.5ZM5.25 3A1.97 1.97 0 1 0 5.3 6.94 1.97 1.97 0 0 0 5.25 3Zm6.09 5.5H8.1V20h3.24v-5.67c0-1.5.28-2.95 2.13-2.95 1.83 0 1.86 1.72 1.86 3.04V20h3.25v-6.24c0-3.06-.66-5.42-4.24-5.42-1.72 0-2.88.95-3.35 1.85h-.05V8.5Z"
-                />
-              </svg>
+            <a href="https://www.linkedin.com/company/nailnowapp/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn da NailNow">
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5a2.5 2.5 0 11-.02 5 2.5 2.5 0 01.02-5zM3 9h4v12H3V9zm6 0h3.83v1.64h.05c.53-1 1.84-2.06 3.78-2.06C20.5 8.58 22 10.28 22 13.6V21h-4v-6.56c0-1.56-.03-3.57-2.18-3.57-2.18 0-2.51 1.7-2.51 3.46V21H9V9z"/></svg>
             </a>
-            <a
-              class="social-link"
-              href="https://www.facebook.com/NailNowapp/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Facebook da NailNow"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  d="M13.5 21v-8.1h2.7l.4-3.15h-3.1V7.73c0-.91.25-1.53 1.56-1.53h1.67V3.38c-.29-.04-1.27-.12-2.41-.12-2.38 0-4.01 1.45-4.01 4.12v2.36H8v3.15h2.32V21h3.18Z"
-                />
-              </svg>
+            <a href="https://www.facebook.com/NailNowapp/" target="_blank" rel="noopener noreferrer" aria-label="Facebook da NailNow">
+              <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M22 12a10 10 0 10-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.5 1.49-3.89 3.78-3.89 1.09 0 2.24.2 2.24.2v2.46h-1.26c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0022 12z"/></svg>
             </a>
           </div>
         </div>
+        <button class="nn-tb-toggle" id="nnTbToggle" aria-label="Abrir menu" aria-expanded="false">☰</button>
+      </div>
+      <div class="nn-tb-mobile" id="nnTbMobile" hidden>
+        <a class="nn-tb-m-link" href="/">Home</a>
+        <a class="nn-tb-m-link" href="/como-funciona">Como funciona</a>
+        <a class="nn-tb-m-link" href="/beneficio-corporativo">Benefício corporativo</a>
+        <a class="nn-tb-m-link" href="/feedbacks">Feedbacks</a>
+        <div class="nn-tb-m-actions">
+          <a class="nn-tb-btn is-ghost" href="/profissional">Sou Manicure</a>
+          <a class="nn-tb-btn is-solid" href="/cliente">Sou Cliente</a>
+        </div>
       </div>
     </header>
+    <script>
+      (function(){
+        var t=document.getElementById('nnTbToggle'),m=document.getElementById('nnTbMobile');
+        if(!t||!m)return;
+        t.addEventListener('click',function(){
+          var hidden=m.hasAttribute('hidden');
+          if(hidden){m.removeAttribute('hidden');t.setAttribute('aria-expanded','true');t.textContent='✕';}
+          else{m.setAttribute('hidden','');t.setAttribute('aria-expanded','false');t.textContent='☰';}
+        });
+      })();
+    </script>
 
     <main>
       <style>


### PR DESCRIPTION
## Summary
Troca o header da home (`index.html`) pelo estilo do standalone `~/Downloads/nailnow-home-nova.html` que a Bruna validou:
- Background branco com border-bottom rosa suave
- Logo SVG droplet + "NailNow" em Playfair Display
- Nav inline (Home / Como funciona / Benefício corporativo / Feedbacks)
- "Sou Manicure" (ghost) + "Sou Cliente" (rosa solid)
- Ícones sociais (IG / LinkedIn / FB) com divider

Conteúdo de navegação é idêntico ao header atual — só muda o visual.

## Isolamento
CSS prefixado com `.nn-topbar` (não usa `.topbar`, `.brand`, `.nav` etc, que colidiriam com o `styles.css` global). Outras páginas seguem com `.site-header`.

## Test plan
- [ ] Deploy Vercel ok
- [ ] Home (`nailnow.app/`) com header branco no estilo do standalone
- [ ] Outras páginas (como-funciona, beneficio-corporativo, feedbacks) sem alteração no header
- [ ] Menu mobile (botão ☰) abre/fecha
- [ ] Links Sou Manicure / Sou Cliente / nav funcionam

## Heads up
Header das outras páginas (e do que o Codex padronizou em #543) ainda é o `.site-header` rosa. Se quiser uniformizar tudo, abro outro PR convertendo todas as páginas pra `nn-topbar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)