### PR TITLE
Remove banner promo do lançamento (já lançou)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,19 +1224,6 @@
         alt=""
       />
     </noscript>
-    <div class="promo-banner" role="region" aria-label="Convite para grupo do WhatsApp">
-      <p class="promo-banner__message">
-        💅 Manicures de Porto Alegre: entre no nosso grupo do WhatsApp para ficar por dentro do lançamento do app (maio 2026).
-      </p>
-      <a
-        class="promo-banner__cta"
-        href="https://chat.whatsapp.com/D5xjkvnM8CjLUQQS2EPaQd"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Entrar no WhatsApp
-      </a>
-    </div>
     <style>
       /* Topbar isolada da home — não afeta outras páginas */
       .nn-topbar{--nn-tb-pink:#F45CA2;--nn-tb-pink-strong:#FE68BF;--nn-tb-mauve:#814D68;--nn-tb-line:#E5A8C7;--nn-tb-ink:#1d1320;--nn-tb-ink-soft:#5b4a55;background:#fff;border-bottom:1px solid rgba(229,168,199,.45);position:sticky;top:0;z-index:50;font-family:'Poppins','Inter',system-ui,sans-serif}


### PR DESCRIPTION
## Summary
Remove o banner amarelo no topo da home:

> 💅 Manicures de Porto Alegre: entre no nosso grupo do WhatsApp para ficar por dentro do lançamento do app (maio 2026).

App já lançou em maio 2026 — banner virou ruído, polui o topo da página.

## Test plan
- [ ] Deploy Vercel ok
- [ ] Banner amarelo sumiu do topo
- [ ] Header continua aparecendo normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)