### PR TITLE
Home: remove horário 8-20h + topbar maior

### DIFF
--- a/index.html
+++ b/index.html
@@ -1198,14 +1198,6 @@
             { "@type": "City", "name": "Porto Alegre" },
             { "@type": "AdministrativeArea", "name": "Região Metropolitana de Porto Alegre" }
           ],
-          "openingHoursSpecification": [
-            {
-              "@type": "OpeningHoursSpecification",
-              "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
-              "opens": "08:00",
-              "closes": "20:00"
-            }
-          ],
           "sameAs": [
             "https://www.instagram.com/nailnow/",
             "https://www.linkedin.com/company/nailnowapp/",
@@ -1228,22 +1220,22 @@
       /* Topbar isolada da home — não afeta outras páginas */
       .nn-topbar{--nn-tb-pink:#F45CA2;--nn-tb-pink-strong:#FE68BF;--nn-tb-mauve:#814D68;--nn-tb-line:#E5A8C7;--nn-tb-ink:#1d1320;--nn-tb-ink-soft:#5b4a55;background:#fff;border-bottom:1px solid rgba(229,168,199,.45);position:sticky;top:0;z-index:50;font-family:'Poppins','Inter',system-ui,sans-serif}
       .nn-topbar *{box-sizing:border-box}
-      .nn-topbar .nn-tb-wrap{max-width:min(1640px,96vw);margin:0 auto;padding:0 clamp(20px,3.5vw,56px);display:flex;align-items:center;gap:20px;height:84px}
-      .nn-topbar .nn-tb-brand{display:flex;align-items:center;gap:9px;font-family:'Playfair Display',serif;font-weight:700;font-size:1.3rem;color:var(--nn-tb-ink);flex-shrink:0;text-decoration:none}
-      .nn-topbar .nn-tb-brand img{width:30px;height:30px;flex-shrink:0;display:block}
-      .nn-topbar .nn-tb-nav{display:flex;align-items:center;gap:20px;font-size:.88rem;font-weight:500;margin-right:auto;margin-left:6px}
+      .nn-topbar .nn-tb-wrap{max-width:min(1640px,96vw);margin:0 auto;padding:0 clamp(20px,3.5vw,56px);display:flex;align-items:center;gap:24px;height:96px}
+      .nn-topbar .nn-tb-brand{display:flex;align-items:center;gap:11px;font-family:'Playfair Display',serif;font-weight:700;font-size:clamp(1.4rem,1.6vw,1.65rem);color:var(--nn-tb-ink);flex-shrink:0;text-decoration:none}
+      .nn-topbar .nn-tb-brand img{width:38px;height:38px;flex-shrink:0;display:block}
+      .nn-topbar .nn-tb-nav{display:flex;align-items:center;gap:28px;font-size:clamp(.98rem,1.05vw,1.08rem);font-weight:500;margin-right:auto;margin-left:14px}
       .nn-topbar .nn-tb-nav a{color:var(--nn-tb-ink-soft);white-space:nowrap;text-decoration:none;transition:color .15s ease}
       .nn-topbar .nn-tb-nav a:hover{color:var(--nn-tb-pink)}
-      .nn-topbar .nn-tb-actions{display:flex;align-items:center;gap:11px;flex-shrink:0}
-      .nn-topbar .nn-tb-btn{font-size:.84rem;font-weight:600;padding:9px 15px;border-radius:12px;white-space:nowrap;transition:border-color .15s ease,color .15s ease,background .15s ease;text-decoration:none;display:inline-block;line-height:1.2}
+      .nn-topbar .nn-tb-actions{display:flex;align-items:center;gap:13px;flex-shrink:0}
+      .nn-topbar .nn-tb-btn{font-size:clamp(.92rem,1vw,1.02rem);font-weight:600;padding:12px 20px;border-radius:14px;white-space:nowrap;transition:border-color .15s ease,color .15s ease,background .15s ease;text-decoration:none;display:inline-block;line-height:1.2}
       .nn-topbar .nn-tb-btn.is-ghost{color:var(--nn-tb-mauve);border:1.4px solid var(--nn-tb-line);background:#fff}
       .nn-topbar .nn-tb-btn.is-ghost:hover{border-color:var(--nn-tb-pink);color:var(--nn-tb-pink)}
       .nn-topbar .nn-tb-btn.is-solid{background:var(--nn-tb-pink);color:#fff;border:1.4px solid var(--nn-tb-pink)}
       .nn-topbar .nn-tb-btn.is-solid:hover{background:var(--nn-tb-pink-strong);border-color:var(--nn-tb-pink-strong)}
-      .nn-topbar .nn-tb-socials{display:flex;align-items:center;gap:11px;padding-left:13px;border-left:1px solid var(--nn-tb-line)}
+      .nn-topbar .nn-tb-socials{display:flex;align-items:center;gap:13px;padding-left:15px;border-left:1px solid var(--nn-tb-line)}
       .nn-topbar .nn-tb-socials a{color:var(--nn-tb-mauve);display:flex;transition:color .15s ease}
       .nn-topbar .nn-tb-socials a:hover{color:var(--nn-tb-pink)}
-      .nn-topbar .nn-tb-socials svg{width:18px;height:18px}
+      .nn-topbar .nn-tb-socials svg{width:22px;height:22px}
       .nn-topbar .nn-tb-toggle{display:none;background:none;border:0;cursor:pointer;font-size:1.5rem;line-height:1;color:var(--nn-tb-mauve);margin-left:auto;padding:6px 10px}
       .nn-topbar .nn-tb-mobile{display:none;flex-direction:column;gap:4px;padding:14px 24px 20px;border-bottom:1px solid rgba(229,168,199,.45);background:#fff}
       .nn-topbar .nn-tb-mobile a.nn-tb-m-link{padding:11px 4px;font-weight:500;color:var(--nn-tb-ink);border-bottom:1px solid rgba(229,168,199,.3);text-decoration:none}
@@ -1562,7 +1554,7 @@
               </div>
               <div class="nn-stat">
                 <div class="nn-num">7</div>
-                <div class="nn-lbl">dias por semana, das 8h às 20h</div>
+                <div class="nn-lbl">dias por semana</div>
               </div>
             </div>
           </div>
@@ -1698,7 +1690,7 @@
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12.04 2C6.58 2 2.13 6.45 2.13 11.91c0 1.75.46 3.45 1.32 4.95L2 22l5.25-1.38c1.45.79 3.08 1.21 4.79 1.21 5.46 0 9.91-4.45 9.91-9.91C21.95 6.45 17.5 2 12.04 2zm0 18.13c-1.52 0-3.01-.41-4.3-1.18l-.31-.18-3.12.82.83-3.04-.2-.31a8.2 8.2 0 01-1.26-4.35c0-4.54 3.7-8.23 8.25-8.23 2.2 0 4.27.86 5.83 2.42a8.18 8.18 0 012.41 5.82c0 4.54-3.7 8.23-8.23 8.23zm4.52-6.16c-.25-.12-1.47-.72-1.69-.81-.23-.08-.39-.12-.56.13-.16.25-.64.81-.79.97-.14.17-.29.19-.54.06-.25-.12-1.05-.39-1.99-1.23-.74-.66-1.23-1.47-1.38-1.72-.14-.25-.01-.38.11-.51.11-.11.25-.29.37-.43.13-.14.17-.25.25-.41.08-.17.04-.31-.02-.43-.06-.12-.56-1.34-.76-1.84-.2-.48-.41-.42-.56-.43h-.48c-.17 0-.43.06-.66.31-.22.25-.86.85-.86 2.07 0 1.22.89 2.4 1.01 2.56.12.17 1.75 2.67 4.23 3.74.59.26 1.05.41 1.41.52.59.19 1.13.16 1.56.1.48-.07 1.47-.6 1.68-1.18.21-.58.21-1.07.14-1.18-.06-.1-.22-.16-.47-.28z"/></svg>
         Agendar pelo WhatsApp
       </span>
-      <span class="nn-sticky-sub">Resposta em minutos · seg–dom 8h–20h</span>
+      <span class="nn-sticky-sub">Resposta em minutos · 7 dias por semana</span>
     </a>
     <a class="nn-home-float-cta" id="nnFloatCta" href="https://wa.me/555191518097?text=Oi!%20Vi%20o%20site%20da%20NailNow%20e%20quero%20agendar%20uma%20manicure%20a%20domic%C3%ADlio." target="_blank" rel="noopener" aria-label="Agendar pelo WhatsApp">
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12.04 2C6.58 2 2.13 6.45 2.13 11.91c0 1.75.46 3.45 1.32 4.95L2 22l5.25-1.38c1.45.79 3.08 1.21 4.79 1.21 5.46 0 9.91-4.45 9.91-9.91C21.95 6.45 17.5 2 12.04 2zm0 18.13c-1.52 0-3.01-.41-4.3-1.18l-.31-.18-3.12.82.83-3.04-.2-.31a8.2 8.2 0 01-1.26-4.35c0-4.54 3.7-8.23 8.25-8.23 2.2 0 4.27.86 5.83 2.42a8.18 8.18 0 012.41 5.82c0 4.54-3.7 8.23-8.23 8.23zm4.52-6.16c-.25-.12-1.47-.72-1.69-.81-.23-.08-.39-.12-.56.13-.16.25-.64.81-.79.97-.14.17-.29.19-.54.06-.25-.12-1.05-.39-1.99-1.23-.74-.66-1.23-1.47-1.38-1.72-.14-.25-.01-.38.11-.51.11-.11.25-.29.37-.43.13-.14.17-.25.25-.41.08-.17.04-.31-.02-.43-.06-.12-.56-1.34-.76-1.84-.2-.48-.41-.42-.56-.43h-.48c-.17 0-.43.06-.66.31-.22.25-.86.85-.86 2.07 0 1.22.89 2.4 1.01 2.56.12.17 1.75 2.67 4.23 3.74.59.26 1.05.41 1.41.52.59.19 1.13.16 1.56.1.48-.07 1.47-.6 1.68-1.18.21-.58.21-1.07.14-1.18-.06-.1-.22-.16-.47-.28z"/></svg>


### PR DESCRIPTION
## Summary
- Remove referências a "8h-20h" da home (stats strip, sticky CTA, JSON-LD openingHours) — fica apenas "7 dias por semana"
- Topbar maior pra ficar proporcional ao hero gigante: height 84→96px, brand/logo +25%, nav +20%, botões +20%

## Test plan
- [ ] Stat "7 dias por semana" sem horário
- [ ] Sticky mobile sem horário
- [ ] Topbar com mais presença visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)